### PR TITLE
Feature/standardize entities naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,8 @@
 /node_modules
 /build
 
+/https
+
 # Logs
 logs
 *.log

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ http://localhost:3000/test-auth
 - **POST** `/guild`
 ```json
 {
-  "uuid": "123456789012345678",
+  "idGuild": "123456789012345678",
   "name": "My Discord Server",
   "memberCount": 100,
   "configuration": {
@@ -244,14 +244,14 @@ http://localhost:3000/test-auth
 - **GET** `/guild`
 
 #### Get One Guild
-- **GET** `/guild/:uuid`
+- **GET** `/guild/:id`
 Example: `/guild/123456789012345678`
 
 #### Update a Guild
-- **PUT** `/guild/:uuid`
+- **PUT** `/guild/:id`
 ```json
 {
-  "uuid": "123456789012345678",
+  "idGuild": "123456789012345678",
   "name": "Updated Server Name",
   "memberCount": 150,
   "configuration": {
@@ -263,7 +263,7 @@ Example: `/guild/123456789012345678`
 ```
 
 #### Delete a Guild
-- **DELETE** `/guild/:uuid`
+- **DELETE** `/guild/:id`
 Example: `/guild/123456789012345678`
 
 ### Campus Endpoints
@@ -280,11 +280,11 @@ Example: `/guild/123456789012345678`
 - **GET** `/campus`
 
 #### Get One Campus
-- **GET** `/campus/:uuid`
+- **GET** `/campus/:id`
 Example: `/campus/550e8400-e29b-41d4-a716-446655440000`
 
 #### Update a Campus
-- **PUT** `/campus/:uuid`
+- **PUT** `/campus/:id`
 ```json
 {
   "name": "Lille"
@@ -292,7 +292,7 @@ Example: `/campus/550e8400-e29b-41d4-a716-446655440000`
 ```
 
 #### Delete a Campus
-- **DELETE** `/campus/:uuid`
+- **DELETE** `/campus/:id`
 Example: `/campus/550e8400-e29b-41d4-a716-446655440000`
 
 ### Guilds-Templates Endpoints
@@ -301,7 +301,7 @@ Example: `/campus/550e8400-e29b-41d4-a716-446655440000`
 - **POST** `/guilds-templates`
 ```json
 {
-  "uuid": "123456789012345678",
+  "idGuildTemplate": "123456789012345678",
   "name": "Server Template",
 }
 ```
@@ -310,11 +310,11 @@ Example: `/campus/550e8400-e29b-41d4-a716-446655440000`
 - **GET** `/guilds-templates`
 
 #### Get One Guild Template
-- **GET** `/guilds-templates/:uuid`
+- **GET** `/guilds-templates/:id`
 Example: `/guilds-templates/123456789012345678`
 
 #### Update a Guild Template
-- **PUT** `/guilds-templates/:uuid`
+- **PUT** `/guilds-templates/:id`
 ```json
 {
   "name": "Updated Template Name",
@@ -322,7 +322,7 @@ Example: `/guilds-templates/123456789012345678`
 ```
 
 #### Delete a Guild Template
-- **DELETE** `/guilds-templates/:uuid`
+- **DELETE** `/guilds-templates/:id`
 Example: `/guilds-templates/123456789012345678`
 
 ### Channel Endpoints
@@ -341,11 +341,11 @@ Example: `/guilds-templates/123456789012345678`
 - **GET** `/channels`
 
 #### Get One Channel
-- **GET** `/channels/:uuid`
+- **GET** `/channels/:id`
 Example: `/channels/123456789012345678`
 
 #### Update a Channel
-- **PUT** `/channels/:uuid`
+- **PUT** `/channels/:id`
 ```json
 {
   "name": "announcements",
@@ -355,7 +355,7 @@ Example: `/channels/123456789012345678`
 ```
 
 #### Delete a Channel
-- **DELETE** `/channels/:uuid`
+- **DELETE** `/channels/:id`
 Example: `/channels/123456789012345678`
 
 ### Promotion Endpoints
@@ -374,11 +374,11 @@ Example: `/channels/123456789012345678`
 - **GET** `/promotions`
 
 #### Get One Promotion
-- **GET** `/promotions/:uuid`
+- **GET** `/promotions/:id`
 Example: `/promotions/550e8400-e29b-41d4-a716-446655440000`
 
 #### Update a Promotion
-- **PUT** `/promotions/:uuid`
+- **PUT** `/promotions/:id`
 ```json
 {
   "name": "Dev Web 2024 - Updated",
@@ -388,13 +388,13 @@ Example: `/promotions/550e8400-e29b-41d4-a716-446655440000`
 ```
 
 #### Delete a Promotion
-- **DELETE** `/promotions/:uuid`
+- **DELETE** `/promotions/:id`
 Example: `/promotions/550e8400-e29b-41d4-a716-446655440000`
 
 Note: 
 - All timestamps (`createdAt`, `updatedAt`) are managed automatically
-- For Guild endpoints, the `uuid` must be a valid Discord server ID (17-20 digits)
-- For Campus endpoints, the `uuid` is automatically generated
+- For Guild endpoints, the `id` must be a valid Discord server ID (17-20 digits)
+- For Campus endpoints, the `id` is automatically generated
 
 ### Roles Endpoints
 
@@ -402,12 +402,12 @@ Note:
 - **POST** `/roles`
 ```json
 {
-  "uuid": "123456789012345678",
+  "idRole": "123456789012345678",
   "name": "Administrateur",
   "color": "#FF0000",
   "permissions": ["MANAGE_CHANNELS", "MANAGE_ROLES"],
-  "position": 1,
-  "uuid_guild": "987654321098765432"
+  "rolePosition": 1,
+  "idGuild": "987654321098765432"
 }
 ```
 
@@ -415,22 +415,22 @@ Note:
 - **GET** `/roles`
 
 #### Get One Role
-- **GET** `/roles/:uuid`
+- **GET** `/roles/:id`
 Example: `/roles/123456789012345678`
 
 #### Update a Role
-- **PUT** `/roles/:uuid`
+- **PUT** `/roles/:id`
 ```json
 {
   "name": "Super Admin",
   "color": "#0000FF",
   "permissions": ["ADMINISTRATOR"],
-  "position": 2
+  "rolePosition": 2
 }
 ```
 
 #### Delete a Role
-- **DELETE** `/roles/:uuid`
+- **DELETE** `/roles/:id`
 Example: `/roles/123456789012345678`
 
 
@@ -441,7 +441,7 @@ Example: `/roles/123456789012345678`
 - **POST** `/identification-requests`
 ```json
 {
-  "uuidMember": "57bb2c9b-a472-408d-9b90-4a834da929d0",
+  "idMember": "57bb2c9b-a472-408d-9b90-4a834da929d0",
   "firstname": "Hidetaka",
   "lastname": "Miyazaki",
   "email": "hidetaka.miyazaki@from-software.com"
@@ -452,14 +452,14 @@ Example: `/roles/123456789012345678`
 - **GET** `/identification-requests`
 
 #### Get One identification request
-- **GET** `/identification-requests/:uuid`  
+- **GET** `/identification-requests/:id`  
 Example: `/identification-requests/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 #### Update identification request
-- **PUT** `/identification-requests/:uuid`
+- **PUT** `/identification-requests/:id`
 ```json
 {
-  "uuidMember": "57bb2c9b-a472-408d-9b90-4a834da929d0",
+  "idMember": "57bb2c9b-a472-408d-9b90-4a834da929d0",
   "firstname": "Hidetaka",
   "lastname": "Miyazaki",
   "email": "hidetaka.miyazaki@from-software.jp"
@@ -467,7 +467,7 @@ Example: `/identification-requests/57bb2c9b-a472-408d-9b90-4a834da929d0`
 ```
 
 #### Delete identification request
-- **DELETE** `/identification-requests/:uuid`  
+- **DELETE** `/identification-requests/:id`  
 Example: `/identification-requests/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 ### Members Informations Endpoints
@@ -477,7 +477,7 @@ Example: `/identification-requests/57bb2c9b-a472-408d-9b90-4a834da929d0`
 - **POST** `/members-informations`
 ```json
 {
-  "uuid-member": "123456789012345678",
+  "idMember": "123456789012345678",
   "firstname": "Hidetaka",
   "lastname": "Miyazaki",
   "email": "hidetaka.miyazaki@from-software.com"
@@ -488,15 +488,15 @@ Example: `/identification-requests/57bb2c9b-a472-408d-9b90-4a834da929d0`
 - **GET** `/members-informations`
 
 #### Get One member informations
-- **GET** `/members-informations/:uuid`
+- **GET** `/members-informations/:id`
 Example: `/members-informations/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 
 #### Update member informations
-- **PUT** `/members-informations/:uuid`
+- **PUT** `/members-informations/:id`
 ```json
 {
-  "uuid-member": "123456789012345678",
+  "idMember": "123456789012345678",
   "firstname": "Hidetaka",
   "lastname": "Miyazaki",
   "email": "hidetaka.miyazaki@from-software.jp"
@@ -505,7 +505,7 @@ Example: `/members-informations/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 #### Delete member informations
 
-- **DELETE** `/members-informations/:uuid`
+- **DELETE** `/members-informations/:id`
 Example: `/members-informations/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 ### Categories Endpoints
@@ -515,10 +515,10 @@ Example: `/members-informations/57bb2c9b-a472-408d-9b90-4a834da929d0`
 - **POST** `/categories`
 ```json
 {
-  "uuid": "123456789012345678",
-  "uuidGuild": "987654321098765432",
+  "idCategory": "123456789012345678",
+  "idGuild": "987654321098765432",
   "name": "General",
-  "position": 1
+  "categoryPosition": 1
 }
 ```
 
@@ -526,28 +526,28 @@ Example: `/members-informations/57bb2c9b-a472-408d-9b90-4a834da929d0`
 - **GET** `/categories`
 
 #### Get One category
-- **GET** `/categories/:uuid`  
+- **GET** `/categories/:id`  
 Example: `/categories/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 #### Update category
-- **PUT** `/categories/:uuid`
+- **PUT** `/categories/:id`
 ```json
 {
-  "uuid": "123456789012345678",
-  "uuidGuild": "987654321098765432",
+  "idCategory": "123456789012345678",
+  "idGuild": "987654321098765432",
   "name": "Updated Category",
-  "position": 2
+  "categoryPosition": 2
 }
 ```
 
 #### Delete category
-- **DELETE** `/categories/:uuid`  
+- **DELETE** `/categories/:id`  
 Example: `/categories/57bb2c9b-a472-408d-9b90-4a834da929d0`
 
 Note: 
 - All timestamps (`createdAt`, `updatedAt`) are managed automatically
-- For Guild endpoints, the `uuid` must be a valid Discord server ID (17-20 digits)
-- For Campus endpoints, the `uuid` is automatically generated
+- For Guild endpoints, the `id` must be a valid Discord server ID (17-20 digits)
+- For Campus endpoints, the `id` is automatically generated
 
 ### Answers Endpoints
 
@@ -557,7 +557,7 @@ Note:
 {
   "content": "Paris",
   "isMultipleAnswer": false,
-  "questionUuid": "123e4567-e89b-12d3-a456-426614174000"
+  "idQuestion": "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 
@@ -565,11 +565,11 @@ Note:
 - **GET** `/answers`
 
 #### Get One Answer
-- **GET** `/answers/:uuid`
+- **GET** `/answers/:id`
 Example: `/answers/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update an Answer
-- **PUT** `/answers/:uuid`
+- **PUT** `/answers/:id`
 ```json
 {
   "content": "Updated answer",
@@ -578,7 +578,7 @@ Example: `/answers/123e4567-e89b-12d3-a456-426614174000`
 ```
 
 #### Delete an Answer
-- **DELETE** `/answers/:uuid`
+- **DELETE** `/answers/:id`
 Example: `/answers/123e4567-e89b-12d3-a456-426614174000`
 
 ### Comments Endpoints
@@ -589,9 +589,9 @@ Example: `/answers/123e4567-e89b-12d3-a456-426614174000`
 {
   "content": "Très bon travail sur ce projet !",
   "comment_status": "active",
-  "uuid_member": "123e4567-e89b-12d3-a456-426614174000",
-  "resource_uuid": "123e4567-e89b-12d3-a456-426614174000",
-  "user_uuid": "123e4567-e89b-12d3-a456-426614174000"
+  "idMember": "123e4567-e89b-12d3-a456-426614174000",
+  "idResource": "123e4567-e89b-12d3-a456-426614174000",
+  "idUser": "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 
@@ -599,11 +599,11 @@ Example: `/answers/123e4567-e89b-12d3-a456-426614174000`
 - **GET** `/comments`
 
 #### Get One Comment
-- **GET** `/comments/:uuid`
+- **GET** `/comments/:id`
 Example: `/comments/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Comment
-- **PATCH** `/comments/:uuid`
+- **PATCH** `/comments/:id`
 ```json
 {
   "content": "Contenu mis à jour",
@@ -612,7 +612,7 @@ Example: `/comments/123e4567-e89b-12d3-a456-426614174000`
 ```
 
 #### Delete a Comment
-- **DELETE** `/comments/:uuid`
+- **DELETE** `/comments/:id`
 Example: `/comments/123e4567-e89b-12d3-a456-426614174000`
 
 ### Courses Endpoints
@@ -623,8 +623,8 @@ Example: `/comments/123e4567-e89b-12d3-a456-426614174000`
 {
   "name": "cda-vals-p4",
   "isCertified": true,
-  "uuidGuild": "123456789012345678",
-  "uuidCategory": "123456789012345678"
+  "idGuild": "123456789012345678",
+  "idCategory": "123456789012345678"
 }
 ```
 
@@ -632,11 +632,11 @@ Example: `/comments/123e4567-e89b-12d3-a456-426614174000`
 - **GET** `/courses`
 
 #### Get One Course
-- **GET** `/courses/:uuid`
+- **GET** `/courses/:id`
 Example: `/courses/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Course
-- **PUT** `/courses/:uuid`
+- **PUT** `/courses/:id`
 ```json
 {
   "name": "updated-course",
@@ -645,7 +645,7 @@ Example: `/courses/123e4567-e89b-12d3-a456-426614174000`
 ```
 
 #### Delete a Course
-- **DELETE** `/courses/:uuid`
+- **DELETE** `/courses/:id`
 Example: `/courses/123e4567-e89b-12d3-a456-426614174000`
 
 ### Dashboard Accounts Endpoints
@@ -656,16 +656,16 @@ Example: `/courses/123e4567-e89b-12d3-a456-426614174000`
 {
   "email": "test@example.com",
   "password": "password123",
-  "uuid_discord": "123456789012345678"
+  "idDiscord": "123456789012345678"
 }
 ```
 
 #### Get One Dashboard Account
-- **GET** `/dashboardAccounts/:uuid_dashboard_account`
+- **GET** `/dashboardAccounts/:idSashboardAccount`
 Example: `/dashboardAccounts/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Dashboard Account
-- **PUT** `/dashboardAccounts/:uuid_dashboard_account`
+- **PUT** `/dashboardAccounts/:idDashboardAccount`
 ```json
 {
   "email": "updated@example.com",
@@ -674,7 +674,7 @@ Example: `/dashboardAccounts/123e4567-e89b-12d3-a456-426614174000`
 ```
 
 #### Delete a Dashboard Account
-- **DELETE** `/dashboardAccounts/:uuid_dashboard_account`
+- **DELETE** `/dashboardAccounts/:idDashboardAccount`
 Example: `/dashboardAccounts/123e4567-e89b-12d3-a456-426614174000`
 
 ### Discord Users Endpoints
@@ -683,7 +683,7 @@ Example: `/dashboardAccounts/123e4567-e89b-12d3-a456-426614174000`
 - **POST** `/discord-users`
 ```json
 {
-  "uuid_discord": "123456789012345678",
+  "idDiscord": "123456789012345678",
   "discordUsername": "JohnDoe#1234",
   "discriminator": "1234"
 }
@@ -693,11 +693,11 @@ Example: `/dashboardAccounts/123e4567-e89b-12d3-a456-426614174000`
 - **GET** `/discord-users`
 
 #### Get One Discord User
-- **GET** `/discord-users/:uuid_discord`
+- **GET** `/discord-users/:idDiscord`
 Example: `/discord-users/123456789012345678`
 
 #### Update a Discord User
-- **PUT** `/discord-users/:uuid_discord`
+- **PUT** `/discord-users/:idDiscord`
 ```json
 {
   "discordUsername": "UpdatedJohnDoe#1234",
@@ -706,7 +706,7 @@ Example: `/discord-users/123456789012345678`
 ```
 
 #### Delete a Discord User
-- **DELETE** `/discord-users/:uuid_discord`
+- **DELETE** `/discord-users/:idDiscord`
 Example: `/discord-users/123456789012345678`
 
 ### Members Endpoints
@@ -715,13 +715,13 @@ Example: `/discord-users/123456789012345678`
 - **POST** `/members`
 ```json
 {
-  "guild_username": "JohnDoe",
+  "guildUsername": "JohnDoe",
   "xp": "100.00",
   "level": 1,
-  "community_role": "Member",
+  "communityRole": "Member",
   "status": "Active",
-  "uuid_guild": "123456789012345678",
-  "uuid_discord": "123456789012345678"
+  "idGuild": "123456789012345678",
+  "idDiscord": "123456789012345678"
 }
 ```
 
@@ -729,23 +729,23 @@ Example: `/discord-users/123456789012345678`
 - **GET** `/members`
 
 #### Get One Member
-- **GET** `/members/:uuid`
+- **GET** `/members/:id`
 Example: `/members/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Member
-- **PATCH** `/members/:uuid`
+- **PATCH** `/members/:id`
 ```json
 {
-  "guild_username": "UpdatedUser",
+  "guildUsername": "UpdatedUser",
   "status": "Inactive",
   "level": 2,
   "xp": "200.00",
-  "community_role": "Moderator"
+  "communityRole": "Moderator"
 }
 ```
 
 #### Delete a Member
-- **DELETE** `/members/:uuid`
+- **DELETE** `/members/:id`
 Example: `/members/123e4567-e89b-12d3-a456-426614174000`
 
 ### Resources Endpoints
@@ -758,7 +758,7 @@ Example: `/members/123e4567-e89b-12d3-a456-426614174000`
   "description": "Un guide complet pour démarrer avec le bot",
   "content": "Voici les étapes pour configurer le bot...",
   "status": "active",
-  "uuid_member": "123e4567-e89b-12d3-a456-426614174000"
+  "idMember": "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 
@@ -766,11 +766,11 @@ Example: `/members/123e4567-e89b-12d3-a456-426614174000`
 - **GET** `/resources`
 
 #### Get One Resource
-- **GET** `/resources/:uuid`
+- **GET** `/resources/:id`
 Example: `/resources/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Resource
-- **PATCH** `/resources/:uuid`
+- **PATCH** `/resources/:id`
 ```json
 {
   "title": "Guide de démarrage mis à jour",
@@ -781,7 +781,7 @@ Example: `/resources/123e4567-e89b-12d3-a456-426614174000`
 ```
 
 #### Delete a Resource
-- **DELETE** `/resources/:uuid`
+- **DELETE** `/resources/:id`
 Example: `/resources/123e4567-e89b-12d3-a456-426614174000`
 
 ### Reports Endpoints
@@ -793,8 +793,8 @@ Example: `/resources/123e4567-e89b-12d3-a456-426614174000`
   "type": "resource",
   "category": "inappropriate",
   "reason": "Contenu offensant envers la communauté",
-  "uuid_resource": "123e4567-e89b-12d3-a456-426614174000",
-  "uuid_reporter": "323b07a1-7cea-4916-82a5-76ff201fa0e2"
+  "idResource": "123e4567-e89b-12d3-a456-426614174000",
+  "idReporter": "323b07a1-7cea-4916-82a5-76ff201fa0e2"
 }
 ```
 
@@ -802,11 +802,11 @@ Example: `/resources/123e4567-e89b-12d3-a456-426614174000`
 - **GET** `/reports`
 
 #### Get One Report
-- **GET** `/reports/:uuid_report`
+- **GET** `/reports/:id_report`
 Example: `/reports/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Report
-- **PATCH** `/reports/:uuid_report`
+- **PATCH** `/reports/:id_report`
 ```json
 {
   "status": "resolved",
@@ -816,7 +816,7 @@ Example: `/reports/123e4567-e89b-12d3-a456-426614174000`
 Note: Seuls les modérateurs peuvent mettre à jour les signalements.
 
 #### Delete a Report
-- **DELETE** `/reports/:uuid_report`
+- **DELETE** `/reports/:id_report`
 Example: `/reports/123e4567-e89b-12d3-a456-426614174000`
 Note: Un utilisateur ne peut supprimer que ses propres signalements.
 
@@ -828,7 +828,7 @@ Note: Un utilisateur ne peut supprimer que ses propres signalements.
 {
   "content": "Quelle est la capitale de la France ?",
   "isMultipleAnswer": false,
-  "uuidPoll": "123e4567-e89b-12d3-a456-426614174000"
+  "idPoll": "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 
@@ -836,11 +836,11 @@ Note: Un utilisateur ne peut supprimer que ses propres signalements.
 - **GET** `/questions`
 
 #### Get One Question
-- **GET** `/questions/:uuid`
+- **GET** `/questions/:id`
 Example: `/questions/123e4567-e89b-12d3-a456-426614174000`
 
 #### Update a Question
-- **PUT** `/questions/:uuid`
+- **PUT** `/questions/:id`
 ```json
 {
   "content": "Quelle est la capitale de l'Italie ?",
@@ -849,7 +849,7 @@ Example: `/questions/123e4567-e89b-12d3-a456-426614174000`
 ```
 
 #### Delete a Question
-- **DELETE** `/questions/:uuid`
+- **DELETE** `/questions/:id`
 Example: `/questions/123e4567-e89b-12d3-a456-426614174000`
 
 ### Votes Endpoints
@@ -858,8 +858,8 @@ Example: `/questions/123e4567-e89b-12d3-a456-426614174000`
 - **POST** `/votes`
 ```json
 {
-  "userId": "123e4567-e89b-12d3-a456-426614174000",
-  "itemId": "123e4567-e89b-12d3-a456-426614174000",
+  "idUser": "123e4567-e89b-12d3-a456-426614174000",
+  "idItem": "123e4567-e89b-12d3-a456-426614174000",
   "voteType": "upvote"
 }
 ```
@@ -890,14 +890,14 @@ Example: `/votes/123e4567-e89b-12d3-a456-426614174000`
 - **POST** `/xp-transactions`
 ```json
 {
-  "transaction_type": "GAIN",
+  "transactionType": "GAIN",
   "source": "VOTE",
-  "transaction_value": "100.00",
+  "transactionValue": "100.00",
   "reason": "Vote positif sur une ressource",
   "notes": "Ressource particulièrement utile",
-  "reference_type": "RESOURCE",
-  "reference_uuid": "123e4567-e89b-12d3-a456-426614174000",
-  "uuid_member": "123e4567-e89b-12d3-a456-426614174000"
+  "referenceType": "RESOURCE",
+  "idReference": "123e4567-e89b-12d3-a456-426614174000",
+  "idMember": "123e4567-e89b-12d3-a456-426614174000"
 }
 ```
 
@@ -905,11 +905,11 @@ Example: `/votes/123e4567-e89b-12d3-a456-426614174000`
 - **GET** `/xp-transactions`
 
 #### Get Member's XP Transactions
-- **GET** `/xp-transactions/member/:uuid_member`
+- **GET** `/xp-transactions/member/:idMember`
 Example: `/xp-transactions/member/123e4567-e89b-12d3-a456-426614174000`
 
 #### Get One XP Transaction
-- **GET** `/xp-transactions/:uuid`
+- **GET** `/xp-transactions/:id`
 Example: `/xp-transactions/123e4567-e89b-12d3-a456-426614174000`
 
 Note: Les transactions XP ne peuvent pas être modifiées ou supprimées une fois créées pour maintenir l'intégrité des données.
@@ -921,7 +921,7 @@ Note: Les transactions XP ne peuvent pas être modifiées ou supprimées une foi
 - **Corps de la requête** :
 ```json
 {
-  "userId": "123e4567-e89b-12d3-a456-426614174001",
+  "idUser": "123e4567-e89b-12d3-a456-426614174001",
   "actionType": "ban",
   "reason": "Violation des règles de la communauté",
   "duration": "24h",

--- a/src/answer-templates/answer-templates.controller.spec.ts
+++ b/src/answer-templates/answer-templates.controller.spec.ts
@@ -41,9 +41,9 @@ describe('AnswerTemplatesController', () => {
     it('should create a new answer', async () => {
       const createAnswerQuestionDto: CreateAnswerQuestionTemplateDto = {
         content: 'Test answer',
-        uuidQuestionTemplate: 'test-question-uuid'
+        idQuestionTemplate: 'test-question-id'
       };
-      const expectedResult = { uuid: 'test-uuid', ...createAnswerQuestionDto };
+      const expectedResult = { id: 'test-id', ...createAnswerQuestionDto };
 
       mockAnswersService.create.mockResolvedValue(expectedResult);
 
@@ -57,8 +57,8 @@ describe('AnswerTemplatesController', () => {
   describe('findAll', () => {
     it('should return an array of answers', async () => {
       const expectedResult = [
-        { uuid: 'uuid1', content: 'Answer 1', uuidQuestionTemplate: 'q-uuid1' },
-        { uuid: 'uuid2', content: 'Answer 2', uuidQuestionTemplate: 'q-uuid2' }
+        { id: 'id1', content: 'Answer 1', idQuestionTemplate: 'q-id1' },
+        { id: 'id2', content: 'Answer 2', idQuestionTemplate: 'q-id2' }
       ];
 
       mockAnswersService.findAll.mockResolvedValue(expectedResult);
@@ -72,68 +72,68 @@ describe('AnswerTemplatesController', () => {
 
   describe('findOne', () => {
     it('should return a single answer', async () => {
-      const uuid = 'test-uuid';
+      const id = 'test-id';
       const expectedResult = {
-        uuid,
+        id,
         content: 'Test answer',
-        uuidQuestionTemplate: 'q-uuid'
+        idQuestionTemplate: 'q-id'
       };
 
       mockAnswersService.findOne.mockResolvedValue(expectedResult);
 
-      const result = await controller.findOne(uuid);
+      const result = await controller.findOne(id);
 
       expect(result).toEqual(expectedResult);
-      expect(service.findOne).toHaveBeenCalledWith(uuid);
+      expect(service.findOne).toHaveBeenCalledWith(id);
     });
   });
 
   describe('update', () => {
     it('should update an answer', async () => {
-      const uuid = 'test-uuid';
+      const id = 'test-id';
       const updateAnswerDto: UpdateAnswerTemplateDto = {
         content: 'Updated answer'
       };
       const expectedResult = {
-        uuid,
+        id,
         ...updateAnswerDto,
-        uuidQuestionTemplate: 'q-uuid'
+        idQuestionTemplate: 'q-id'
       };
 
       mockAnswersService.update.mockResolvedValue(expectedResult);
 
-      const result = await controller.update(uuid, updateAnswerDto);
+      const result = await controller.update(id, updateAnswerDto);
 
       expect(result).toEqual(expectedResult);
-      expect(service.update).toHaveBeenCalledWith(uuid, updateAnswerDto);
+      expect(service.update).toHaveBeenCalledWith(id, updateAnswerDto);
     });
 
     it('should throw NotFoundException when answer not found', async () => {
-      const uuid = 'non-existent-uuid';
+      const id = 'non-existent-id';
       const updateAnswerDto: UpdateAnswerTemplateDto = {
         content: 'Updated answer'
       };
 
       mockAnswersService.update.mockResolvedValue(null);
 
-      await expect(controller.update(uuid, updateAnswerDto)).rejects.toThrow(
+      await expect(controller.update(id, updateAnswerDto)).rejects.toThrow(
         NotFoundException,
       );
-      expect(service.update).toHaveBeenCalledWith(uuid, updateAnswerDto);
+      expect(service.update).toHaveBeenCalledWith(id, updateAnswerDto);
     });
   });
 
   describe('remove', () => {
     it('should remove an answer', async () => {
-      const uuid = 'test-uuid';
+      const id = 'test-id';
       const expectedResult = { deleted: true };
 
       mockAnswersService.remove.mockResolvedValue(expectedResult);
 
-      const result = await controller.remove(uuid);
+      const result = await controller.remove(id);
 
       expect(result).toEqual(expectedResult);
-      expect(service.remove).toHaveBeenCalledWith(uuid);
+      expect(service.remove).toHaveBeenCalledWith(id);
     });
   });
 });

--- a/src/answer-templates/answer-templates.controller.ts
+++ b/src/answer-templates/answer-templates.controller.ts
@@ -43,14 +43,14 @@ export class AnswerTemplatesController {
     return this.answersService.findAll();
   }
 
-  @Get(':uuid')
+  @Get(':id')
   @ApiOperation({
-    summary: 'Get an answer by UUID',
-    description: 'Returns a single answer based on its UUID.'
+    summary: 'Get an answer by id',
+    description: 'Returns a single answer based on its id.'
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID of the answer to retrieve',
+    name: 'id',
+    description: 'id of the answer to retrieve',
     type: String,
     required: true
   })
@@ -61,20 +61,20 @@ export class AnswerTemplatesController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Answer with the specified UUID was not found.'
+    description: 'Answer with the specified id was not found.'
   })
-  findOne(@Param('uuid') uuid: string) {
-    return this.answersService.findOne(uuid);
+  findOne(@Param('id') id: string) {
+    return this.answersService.findOne(id);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({
     summary: 'Update an answer',
-    description: 'Updates an existing answer based on its UUID with the provided information.'
+    description: 'Updates an existing answer based on its id with the provided information.'
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID of the answer to update',
+    name: 'id',
+    description: 'id of the answer to update',
     type: String,
     required: true
   })
@@ -86,28 +86,28 @@ export class AnswerTemplatesController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Answer with the specified UUID was not found.'
+    description: 'Answer with the specified id was not found.'
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: 'Invalid data provided in the request.'
   })
-  async update(@Param('uuid') uuid: string, @Body() updateAnswerDto: UpdateAnswerTemplateDto) {
-    const answer = await this.answersService.update(uuid, updateAnswerDto);
+  async update(@Param('id') id: string, @Body() updateAnswerDto: UpdateAnswerTemplateDto) {
+    const answer = await this.answersService.update(id, updateAnswerDto);
     if (!answer) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${id}" not found`);
     }
     return answer;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({
     summary: 'Delete an answer',
-    description: 'Deletes an existing answer based on its UUID.'
+    description: 'Deletes an existing answer based on its id.'
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID of the answer to delete',
+    name: 'id',
+    description: 'id of the answer to delete',
     type: String,
     required: true
   })
@@ -117,9 +117,9 @@ export class AnswerTemplatesController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Answer with the specified UUID was not found.'
+    description: 'Answer with the specified id was not found.'
   })
-  remove(@Param('uuid') uuid: string) {
-    return this.answersService.remove(uuid);
+  remove(@Param('id') id: string) {
+    return this.answersService.remove(id);
   }
 }

--- a/src/answer-templates/answer-templates.integration.spec.ts
+++ b/src/answer-templates/answer-templates.integration.spec.ts
@@ -12,7 +12,7 @@ describe('Answer templates Integration Tests', () => {
 
   const testAnswer = {
     content: 'Test answer',
-    uuidQuestionTemplate: '123e4567-e89b-12d3-a456-426614174000'
+    idQuestionTemplate: '123e4567-e89b-12d3-a456-426614174000'
   };
 
   beforeAll(async () => {
@@ -53,7 +53,7 @@ describe('Answer templates Integration Tests', () => {
         .post('/answer-templates')
         .send({
           content: '',
-          uuidQuestionTemplate: 'invalid-uuid'
+          idQuestionTemplate: 'invalid-uuid'
         })
         .expect(400);
     });
@@ -70,20 +70,20 @@ describe('Answer templates Integration Tests', () => {
     });
   });
 
-  describe('/GET answer-templates/:uuid', () => {
+  describe('/GET answer-templates/:id', () => {
     it('should return a single answer', async () => {
       // Créer d'abord une réponse
       const createResponse = await request(app.getHttpServer())
         .post('/answer-templates')
         .send(testAnswer);
 
-      const uuid = createResponse.body.uuid;
+      const id = createResponse.body.id;
 
       return request(app.getHttpServer())
-        .get(`/answer-templates/${uuid}`)
+        .get(`/answer-templates/${id}`)
         .expect(200)
         .then((response) => {
-      expect(response.body.uuid).toBe(uuid);
+      expect(response.body.id).toBe(id);
         });
     });
   });

--- a/src/answer-templates/answer-templates.service.spec.ts
+++ b/src/answer-templates/answer-templates.service.spec.ts
@@ -41,10 +41,10 @@ describe('AnswersService', () => {
     it('should create a new answer', async () => {
       const createAnswerQuestionDto: CreateAnswerQuestionTemplateDto = {
         content: 'Test answer',
-        uuidQuestionTemplate: '123e4567-e89b-12d3-a456-426614174000'
+        idQuestionTemplate: '123e4567-e89b-12d3-a456-426614174000'
       };
 
-      const answer = { uuid: 'test-uuid', ...createAnswerQuestionDto };
+      const answer = { idAnswer: 'test-uuid', ...createAnswerQuestionDto };
       mockRepository.create.mockReturnValue(answer);
       mockRepository.save.mockResolvedValue(answer);
 
@@ -59,8 +59,8 @@ describe('AnswersService', () => {
   describe('findAll', () => {
     it('should return an array of answers', async () => {
       const answers = [
-        { uuid: '1', content: 'Answer 1' },
-        { uuid: '2', content: 'Answer 2' },
+        { idAnswer: '1', content: 'Answer 1' },
+        { idAnswer: '2', content: 'Answer 2' },
       ];
       mockRepository.find.mockResolvedValue(answers);
 
@@ -73,13 +73,13 @@ describe('AnswersService', () => {
 
   describe('findOne', () => {
     it('should return a single answer', async () => {
-      const answer = { uuid: 'test-uuid', content: 'Test answer' };
+      const answer = { idAnswerTemplate: 'test-uuid', content: 'Test answer' };
       mockRepository.findOneBy.mockResolvedValue(answer);
 
       const result = await service.findOne('test-uuid');
 
       expect(result).toEqual(answer);
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: 'test-uuid' });
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idAnswerTemplate: 'test-uuid' });
     });
   });
 });

--- a/src/answer-templates/answer-templates.service.ts
+++ b/src/answer-templates/answer-templates.service.ts
@@ -28,39 +28,39 @@ export class AnswerTemplatesService {
     return answers;
   }
 
-  async findOne(uuid: string) {
-    if (!uuid) {
-      throw new BadRequestException('UUID is required');
+  async findOne(idAnswerTemplate: string) {
+    if (!idAnswerTemplate) {
+      throw new BadRequestException('idAnswerTemplate is required');
     }
-    const answer = await this.answersRepository.findOneBy({ uuid });
+    const answer = await this.answersRepository.findOneBy({ idAnswerTemplate });
     if (!answer) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${idAnswerTemplate}" not found`);
     }
     return answer;
   }
 
-  async update(uuid: string, updateAnswerDto: UpdateAnswerTemplateDto) {
-    if (!uuid) {
-      throw new BadRequestException('UUID is required');
+  async update(idAnswerTemplate: string, updateAnswerDto: UpdateAnswerTemplateDto) {
+    if (!idAnswerTemplate) {
+      throw new BadRequestException('id is required');
     }
     if (!updateAnswerDto) {
       throw new BadRequestException('Update data is required');
     }
-    const answer = await this.answersRepository.findOneBy({ uuid });
+    const answer = await this.answersRepository.findOneBy({ idAnswerTemplate });
     if (!answer) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${idAnswerTemplate}" not found`);
     }
     Object.assign(answer, updateAnswerDto);
     return this.answersRepository.save(answer);
   }
 
-  async remove(uuid: string) {
-    if (!uuid) {
-      throw new BadRequestException('UUID is required');
+  async remove(idAnswerTemplate: string) {
+    if (!idAnswerTemplate) {
+      throw new BadRequestException('id is required');
     }
-    const result = await this.answersRepository.delete({ uuid });
+    const result = await this.answersRepository.delete({ idAnswerTemplate });
     if (result.affected === 0) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${idAnswerTemplate}" not found`);
     }
     return { deleted: true };
   }

--- a/src/answer-templates/dto/create-answer-question-template.dto.ts
+++ b/src/answer-templates/dto/create-answer-question-template.dto.ts
@@ -1,9 +1,9 @@
 import { IntersectionType, PickType } from '@nestjs/swagger';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 import { CreateAnswerTemplateDto } from './create-answer-template.dto';
 
 export class CreateAnswerQuestionTemplateDto extends IntersectionType(
     CreateAnswerTemplateDto, 
-    PickType(PickableInternUUIDFields, ['uuidQuestionTemplate']))
+    PickType(PickableInternIdFields, ['idQuestionTemplate']))
   {
 }

--- a/src/answer-templates/entities/answer-template.entity.ts
+++ b/src/answer-templates/entities/answer-template.entity.ts
@@ -10,8 +10,8 @@ export class AnswerTemplate {
     format: 'uuid',
     readOnly: true
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_answer_template' })
-  uuid: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_answer_template' })
+  idAnswerTemplate: string;
 
   @ApiProperty({
     description: 'The content of the answer',
@@ -27,7 +27,7 @@ export class AnswerTemplate {
     type: () => QuestionTemplate
   })
   @ManyToOne(() => QuestionTemplate, (questionTemplate) => questionTemplate.answerTemplates, {onDelete: 'CASCADE'})
-  @JoinColumn({ name: 'uuid_question_template' })
+  @JoinColumn({ name: 'id_question_template' })
   questionTemplate: QuestionTemplate;
 
 }

--- a/src/answers/answers.controller.spec.ts
+++ b/src/answers/answers.controller.spec.ts
@@ -41,9 +41,9 @@ describe('AnswersController', () => {
     it('should create a new answer', async () => {
       const createAnswerQuestionDto: CreateAnswerQuestionDto = {
         content: 'Test answer',
-        uuidQuestion: 'test-question-uuid'
+        idQuestion: 'test-question-id'
       };
-      const expectedResult = { uuid: 'test-uuid', ...createAnswerQuestionDto };
+      const expectedResult = { id: 'test-id', ...createAnswerQuestionDto };
 
       mockAnswersService.create.mockResolvedValue(expectedResult);
 
@@ -57,8 +57,8 @@ describe('AnswersController', () => {
   describe('findAll', () => {
     it('should return an array of answers', async () => {
       const expectedResult = [
-        { uuid: 'uuid1', content: 'Answer 1', uuidQuestion: 'q-uuid1' },
-        { uuid: 'uuid2', content: 'Answer 2', uuidQuestion: 'q-uuid2' }
+        { id: 'id1', content: 'Answer 1', idQuestion: 'q-id1' },
+        { id: 'id2', content: 'Answer 2', idQuestion: 'q-id2' }
       ];
 
       mockAnswersService.findAll.mockResolvedValue(expectedResult);
@@ -72,68 +72,68 @@ describe('AnswersController', () => {
 
   describe('findOne', () => {
     it('should return a single answer', async () => {
-      const uuid = 'test-uuid';
+      const id = 'test-id';
       const expectedResult = {
-        uuid,
+        id,
         content: 'Test answer',
-        uuidQuestion: 'q-uuid'
+        idQuestion: 'q-id'
       };
 
       mockAnswersService.findOne.mockResolvedValue(expectedResult);
 
-      const result = await controller.findOne(uuid);
+      const result = await controller.findOne(id);
 
       expect(result).toEqual(expectedResult);
-      expect(service.findOne).toHaveBeenCalledWith(uuid);
+      expect(service.findOne).toHaveBeenCalledWith(id);
     });
   });
 
   describe('update', () => {
     it('should update an answer', async () => {
-      const uuid = 'test-uuid';
+      const id = 'test-id';
       const updateAnswerDto: UpdateAnswerDto = {
         content: 'Updated answer'
       };
       const expectedResult = {
-        uuid,
+        id,
         ...updateAnswerDto,
-        uuidQuestion: 'q-uuid'
+        idQuestion: 'q-id'
       };
 
       mockAnswersService.update.mockResolvedValue(expectedResult);
 
-      const result = await controller.update(uuid, updateAnswerDto);
+      const result = await controller.update(id, updateAnswerDto);
 
       expect(result).toEqual(expectedResult);
-      expect(service.update).toHaveBeenCalledWith(uuid, updateAnswerDto);
+      expect(service.update).toHaveBeenCalledWith(id, updateAnswerDto);
     });
 
     it('should throw NotFoundException when answer not found', async () => {
-      const uuid = 'non-existent-uuid';
+      const id = 'non-existent-id';
       const updateAnswerDto: UpdateAnswerDto = {
         content: 'Updated answer'
       };
 
       mockAnswersService.update.mockResolvedValue(null);
 
-      await expect(controller.update(uuid, updateAnswerDto)).rejects.toThrow(
+      await expect(controller.update(id, updateAnswerDto)).rejects.toThrow(
         NotFoundException,
       );
-      expect(service.update).toHaveBeenCalledWith(uuid, updateAnswerDto);
+      expect(service.update).toHaveBeenCalledWith(id, updateAnswerDto);
     });
   });
 
   describe('remove', () => {
     it('should remove an answer', async () => {
-      const uuid = 'test-uuid';
+      const id = 'test-id';
       const expectedResult = { deleted: true };
 
       mockAnswersService.remove.mockResolvedValue(expectedResult);
 
-      const result = await controller.remove(uuid);
+      const result = await controller.remove(id);
 
       expect(result).toEqual(expectedResult);
-      expect(service.remove).toHaveBeenCalledWith(uuid);
+      expect(service.remove).toHaveBeenCalledWith(id);
     });
   });
 });

--- a/src/answers/answers.controller.ts
+++ b/src/answers/answers.controller.ts
@@ -43,14 +43,14 @@ export class AnswersController {
     return this.answersService.findAll();
   }
 
-  @Get(':uuid')
+  @Get(':id')
   @ApiOperation({
-    summary: 'Get an answer by UUID',
-    description: 'Returns a single answer based on its UUID.'
+    summary: 'Get an answer by id',
+    description: 'Returns a single answer based on its id.'
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID of the answer to retrieve',
+    name: 'id',
+    description: 'id of the answer to retrieve',
     type: String,
     required: true
   })
@@ -61,20 +61,20 @@ export class AnswersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Answer with the specified UUID was not found.'
+    description: 'Answer with the specified id was not found.'
   })
-  findOne(@Param('uuid') uuid: string) {
-    return this.answersService.findOne(uuid);
+  findOne(@Param('id') id: string) {
+    return this.answersService.findOne(id);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({
     summary: 'Update an answer',
-    description: 'Updates an existing answer based on its UUID with the provided information.'
+    description: 'Updates an existing answer based on its id with the provided information.'
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID of the answer to update',
+    name: 'id',
+    description: 'id of the answer to update',
     type: String,
     required: true
   })
@@ -86,28 +86,28 @@ export class AnswersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Answer with the specified UUID was not found.'
+    description: 'Answer with the specified id was not found.'
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: 'Invalid data provided in the request.'
   })
-  async update(@Param('uuid') uuid: string, @Body() updateAnswerDto: UpdateAnswerDto) {
-    const answer = await this.answersService.update(uuid, updateAnswerDto);
+  async update(@Param('id') id: string, @Body() updateAnswerDto: UpdateAnswerDto) {
+    const answer = await this.answersService.update(id, updateAnswerDto);
     if (!answer) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${id}" not found`);
     }
     return answer;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({
     summary: 'Delete an answer',
-    description: 'Deletes an existing answer based on its UUID.'
+    description: 'Deletes an existing answer based on its id.'
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID of the answer to delete',
+    name: 'id',
+    description: 'id of the answer to delete',
     type: String,
     required: true
   })
@@ -117,9 +117,9 @@ export class AnswersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: 'Answer with the specified UUID was not found.'
+    description: 'Answer with the specified id was not found.'
   })
-  remove(@Param('uuid') uuid: string) {
-    return this.answersService.remove(uuid);
+  remove(@Param('id') id: string) {
+    return this.answersService.remove(id);
   }
 }

--- a/src/answers/answers.integration.spec.ts
+++ b/src/answers/answers.integration.spec.ts
@@ -15,7 +15,7 @@ describe('Answers Integration Tests', () => {
 
   const testAnswer = {
     content: 'Test answer',
-    uuidQuestion: '123e4567-e89b-12d3-a456-426614174000'
+    idQuestion: '123e4567-e89b-12d3-a456-426614174000'
   };
 
   beforeAll(async () => {
@@ -49,7 +49,7 @@ describe('Answers Integration Tests', () => {
         .send(testAnswer)
         .expect(201)
         .then((response) => {
-      expect(response.body).toHaveProperty('uuid');
+      expect(response.body).toHaveProperty('id');
       expect(response.body.content).toBe(testAnswer.content);
         });
     });
@@ -59,7 +59,7 @@ describe('Answers Integration Tests', () => {
         .post('/answers')
         .send({
           content: '',
-          uuidQuestion: 'invalid-uuid'
+          idQuestion: 'invalid-id'
         })
         .expect(400);
     });
@@ -76,20 +76,20 @@ describe('Answers Integration Tests', () => {
     });
   });
 
-  describe('/GET answers/:uuid', () => {
+  describe('/GET answers/:id', () => {
     it('should return a single answer', async () => {
       // Créer d'abord une réponse
       const createResponse = await request(app.getHttpServer())
         .post('/answers')
         .send(testAnswer);
 
-      const uuid = createResponse.body.uuid;
+      const id = createResponse.body.id;
 
       return request(app.getHttpServer())
-        .get(`/answers/${uuid}`)
+        .get(`/answers/${id}`)
         .expect(200)
         .then((response) => {
-      expect(response.body.uuid).toBe(uuid);
+      expect(response.body.id).toBe(id);
         });
     });
   });

--- a/src/answers/answers.service.spec.ts
+++ b/src/answers/answers.service.spec.ts
@@ -41,10 +41,10 @@ describe('AnswersService', () => {
     it('should create a new answer', async () => {
       const createAnswerQuestionDto: CreateAnswerQuestionDto = {
         content: 'Test answer',
-        uuidQuestion: '123e4567-e89b-12d3-a456-426614174000'
+        idQuestion: '123e4567-e89b-12d3-a456-426614174000'
       };
 
-      const answer = { uuid: 'test-uuid', ...createAnswerQuestionDto };
+      const answer = { idAnswer: 'test-id', ...createAnswerQuestionDto };
       mockRepository.create.mockReturnValue(answer);
       mockRepository.save.mockResolvedValue(answer);
 
@@ -59,8 +59,8 @@ describe('AnswersService', () => {
   describe('findAll', () => {
     it('should return an array of answers', async () => {
       const answers = [
-        { uuid: '1', content: 'Answer 1' },
-        { uuid: '2', content: 'Answer 2' },
+        { idAnswer: '1', content: 'Answer 1' },
+        { idAnswer: '2', content: 'Answer 2' },
       ];
       mockRepository.find.mockResolvedValue(answers);
 
@@ -73,13 +73,13 @@ describe('AnswersService', () => {
 
   describe('findOne', () => {
     it('should return a single answer', async () => {
-      const answer = { uuid: 'test-uuid', content: 'Test answer' };
+      const answer = { idAnswer: 'test-id', content: 'Test answer' };
       mockRepository.findOneBy.mockResolvedValue(answer);
 
-      const result = await service.findOne('test-uuid');
+      const result = await service.findOne('test-id');
 
       expect(result).toEqual(answer);
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: 'test-uuid' });
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idAnswer: 'test-id' });
     });
   });
 });

--- a/src/answers/answers.service.ts
+++ b/src/answers/answers.service.ts
@@ -28,39 +28,39 @@ export class AnswersService {
     return answers;
   }
 
-  async findOne(uuid: string) {
-    if (!uuid) {
-      throw new BadRequestException('UUID is required');
+  async findOne(id: string) {
+    if (!id) {
+      throw new BadRequestException('id is required');
     }
-    const answer = await this.answersRepository.findOneBy({ uuid });
+    const answer = await this.answersRepository.findOneBy({ idAnswer: id });
     if (!answer) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${id}" not found`);
     }
     return answer;
   }
 
-  async update(uuid: string, updateAnswerDto: UpdateAnswerDto) {
-    if (!uuid) {
-      throw new BadRequestException('UUID is required');
+  async update(id: string, updateAnswerDto: UpdateAnswerDto) {
+    if (!id) {
+      throw new BadRequestException('id is required');
     }
     if (!updateAnswerDto) {
       throw new BadRequestException('Update data is required');
     }
-    const answer = await this.answersRepository.findOneBy({ uuid });
+    const answer = await this.answersRepository.findOneBy({ idAnswer: id });
     if (!answer) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${id}" not found`);
     }
     Object.assign(answer, updateAnswerDto);
     return this.answersRepository.save(answer);
   }
 
-  async remove(uuid: string) {
-    if (!uuid) {
-      throw new BadRequestException('UUID is required');
+  async remove(id: string) {
+    if (!id) {
+      throw new BadRequestException('id is required');
     }
-    const result = await this.answersRepository.delete({ uuid });
+    const result = await this.answersRepository.delete({ idAnswer: id });
     if (result.affected === 0) {
-      throw new NotFoundException(`Answer with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Answer with id "${id}" not found`);
     }
     return { deleted: true };
   }

--- a/src/answers/dto/create-answer-question.dto.ts
+++ b/src/answers/dto/create-answer-question.dto.ts
@@ -1,9 +1,9 @@
 import { IntersectionType, PickType } from '@nestjs/swagger';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 import { CreateAnswerDto } from './create-answer.dto';
 
 export class CreateAnswerQuestionDto extends IntersectionType(
     CreateAnswerDto, 
-    PickType(PickableInternUUIDFields, ['uuidQuestion']))
+    PickType(PickableInternIdFields, ['idQuestion']))
   {
 }

--- a/src/answers/entities/answer.entity.ts
+++ b/src/answers/entities/answer.entity.ts
@@ -10,8 +10,8 @@ export class Answer {
     format: 'uuid',
     readOnly: true
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_answer' })
-  uuid: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_answer' })
+  idAnswer: string;
 
   @ApiProperty({
     description: 'The content of the answer',
@@ -27,7 +27,7 @@ export class Answer {
     type: () => Question
   })
   @ManyToOne(() => Question, (question) => question.answers, {onDelete: 'CASCADE'})
-  @JoinColumn({ name: 'uuid_question' })
+  @JoinColumn({ name: 'id_question' })
   question: Question;
 
   @ManyToMany(() => Member, (member) => member.answers)

--- a/src/auth/dto/jwt-payload.dto.ts
+++ b/src/auth/dto/jwt-payload.dto.ts
@@ -1,11 +1,12 @@
 import { ApiProperty } from '@nestjs/swagger';
+import { SetMetadata } from '@nestjs/common';
 
 export class JwtPayloadDto {
   @ApiProperty({
     description: 'ID unique de l\'utilisateur Discord (subject)',
     example: '123456789012345678'
   })
-  sub: string;
+  idUser: string;
 
   @ApiProperty({
     description: 'Nom d\'utilisateur Discord',
@@ -17,11 +18,62 @@ export class JwtPayloadDto {
     description: 'Rôles de l\'utilisateur dans la guilde',
     example: ['member', 'moderator']
   })
-  roles: string[];
+  idRoles: string[];
 
   @ApiProperty({
     description: 'ID de la guilde Discord autorisée',
     example: '123456789012345678'
   })
   guildId: string;
-} 
+}
+
+export class CreateAnswerDto {
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  idQuestion: string;
+}
+
+export class CreateAnswerTemplateDto {
+  @ApiProperty()
+  content: string;
+
+  @ApiProperty()
+  idQuestionTemplate: string;
+}
+
+export interface DiscordUser {
+  idUser: string;
+  username: string;
+  discriminator: string;
+  avatar: string;
+  email?: string;
+  verified?: boolean;
+}
+
+export interface DiscordGuild {
+  idGuild: string;
+  name: string;
+  icon: string;
+  owner: boolean;
+  permissions: number;
+  features: string[];
+}
+
+export interface DiscordGuildMember {
+  user: DiscordUser;
+  nick: string | null;
+  idRoles: string[];
+  joined_at: string;
+  deaf: boolean;
+  mute: boolean;
+}
+
+export interface JwtPayload {
+  idUser: string;
+  username: string;
+  idRoles: string[];
+}
+
+export const Roles = (...idRoles: string[]) => SetMetadata('roles', idRoles); 

--- a/src/campuses/campuses.controller.ts
+++ b/src/campuses/campuses.controller.ts
@@ -25,31 +25,31 @@ export class CampusesController {
     return this.campusService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer un campus par son UUID' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer un campus par son id' })
   @ApiResponse({ status: 200, description: 'Le campus a été trouvé.', type: Campus })
   @ApiResponse({ status: 404, description: 'Campus non trouvé' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.campusService.findOne(uuid);
+  findOne(@Param('id') idCampus: string) {
+    return this.campusService.findOne(idCampus);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour un campus' })
   @ApiResponse({ status: 200, description: 'Le campus a été mis à jour avec succès.', type: Campus })
   @ApiResponse({ status: 404, description: 'Campus non trouvé' })
-  async update(@Param('uuid') uuid: string, @Body() updateCampusDto: UpdateCampusDto) {
-    const campus = await this.campusService.update(uuid, updateCampusDto);
+  async update(@Param('id') idCampus: string, @Body() updateCampusDto: UpdateCampusDto) {
+    const campus = await this.campusService.update(idCampus, updateCampusDto);
     if (!campus) {
-      throw new NotFoundException(`Campus with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Campus with id "${idCampus}" not found`);
     }
     return campus;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer un campus' })
   @ApiResponse({ status: 200, description: 'Le campus a été supprimé avec succès.' })
   @ApiResponse({ status: 404, description: 'Campus non trouvé' })
-  remove(@Param('uuid') uuid: string) {
-    return this.campusService.remove(uuid);
+  remove(@Param('id') idCampus: string) {
+    return this.campusService.remove(idCampus);
   }
 }

--- a/src/campuses/campuses.service.spec.ts
+++ b/src/campuses/campuses.service.spec.ts
@@ -35,14 +35,16 @@ describe('CampusesService', () => {
 
   it('should create a new campus', async () => {
     const dto: CreateCampusDto = { 
+      idCampus: '123e4567-e89b-12d3-a456-426614174000',
       name: 'Test Campus',
-      uuidGuild: '123456789012345678',
-      uuidRole: '234567890123456789'
+      idGuild: '123456789012345678',
+      idRole: '234567890123456789',
+      idCategory: '345678901234567890'
     };
     
     const mockRole = {
-      uuidRole: '234567890123456789',
-      uuidGuild: '123456789012345678',
+      idRole: '234567890123456789',
+      idGuild: '123456789012345678',
       name: 'Test Campus',
       memberCount: 0,
       rolePosition: 0,
@@ -51,8 +53,12 @@ describe('CampusesService', () => {
     };
     
     const entity = { 
-      uuidCampus: '123e4567-e89b-12d3-a456-426614174000', 
-      ...dto 
+      ...dto,
+      idCampus: '123e4567-e89b-12d3-a456-426614174000',
+      category: {
+        idCategory: dto.idCategory,
+        name: 'Test Category'
+      }
     };
     
     mockRoleRepository.create.mockReturnValue(mockRole);
@@ -62,46 +68,46 @@ describe('CampusesService', () => {
 
     expect(await service.create(dto)).toEqual(entity);
     expect(mockRoleRepository.create).toHaveBeenCalledWith(expect.objectContaining({
-      uuidRole: dto.uuidRole,
-      uuidGuild: dto.uuidGuild,
+      idRole: dto.idRole,
+      idGuild: dto.idGuild,
       name: dto.name
     }));
     expect(mockRoleRepository.save).toHaveBeenCalledWith(mockRole);
     expect(mockRepository.create).toHaveBeenCalledWith(expect.objectContaining({
       ...dto,
-      uuidRole: mockRole.uuidRole
+      idRole: mockRole.idRole
     }));
     expect(mockRepository.save).toHaveBeenCalledWith(entity);
   });
 
   it('should return an array of campuses', async () => {
-    const result = [{ uuidCampus: '123e4567-e89b-12d3-a456-426614174000', name: 'Test Campus' }];
+    const result = [{ idCampus: '123e4567-e89b-12d3-a456-426614174000', name: 'Test Campus' }];
     mockRepository.find.mockResolvedValue(result);
     expect(await service.findAll()).toEqual(result);
     expect(mockRepository.find).toHaveBeenCalled();
   });
 
   it('should return a single campus', async () => {
-    const result = { uuidCampus: '123e4567-e89b-12d3-a456-426614174000', name: 'Test Campus' };
+    const result = { idCampus: '123e4567-e89b-12d3-a456-426614174000', name: 'Test Campus' };
     mockRepository.findOneBy.mockResolvedValue(result);
     expect(await service.findOne('123e4567-e89b-12d3-a456-426614174000')).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuidCampus: '123e4567-e89b-12d3-a456-426614174000' });
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idCampus: '123e4567-e89b-12d3-a456-426614174000' });
   });
 
   it('should update a campus', async () => {
     const dto: UpdateCampusDto = { name: 'Updated Campus' };
-    const result = { uuidCampus: '123e4567-e89b-12d3-a456-426614174000', name: 'Updated Campus' };
+    const result = { idCampus: '123e4567-e89b-12d3-a456-426614174000', name: 'Updated Campus' };
     mockRepository.findOneBy.mockResolvedValue(result);
     mockRepository.save.mockResolvedValue(result);
 
     expect(await service.update('123e4567-e89b-12d3-a456-426614174000', dto)).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuidCampus: '123e4567-e89b-12d3-a456-426614174000' });
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idCampus: '123e4567-e89b-12d3-a456-426614174000' });
     expect(mockRepository.save).toHaveBeenCalledWith(result);
   });
 
   it('should delete a campus', async () => {
     mockRepository.delete.mockResolvedValue({ affected: 1 });
     expect(await service.remove('123e4567-e89b-12d3-a456-426614174000')).toEqual({ affected: 1 });
-    expect(mockRepository.delete).toHaveBeenCalledWith({ uuidCampus: '123e4567-e89b-12d3-a456-426614174000' });
+    expect(mockRepository.delete).toHaveBeenCalledWith({ idCampus: '123e4567-e89b-12d3-a456-426614174000' });
   });
 });

--- a/src/campuses/campuses.service.ts
+++ b/src/campuses/campuses.service.ts
@@ -19,8 +19,8 @@ export class CampusesService {
   async create(createCampusDto: CreateCampusDto): Promise<Campus> {
     try {
       const newRole = this.roleRepository.create({
-        uuidRole: createCampusDto.uuidRole, 
-        uuidGuild: createCampusDto.uuidGuild,
+        idRole: createCampusDto.idRole, 
+        idGuild: createCampusDto.idGuild,
         name: createCampusDto.name,
         memberCount: 0,
         rolePosition: 0,
@@ -32,7 +32,7 @@ export class CampusesService {
 
       const newCampus = this.campusRepository.create({
         ...createCampusDto,
-        uuidRole: savedRole.uuidRole,
+        idRole: savedRole.idRole,
       });
 
       return await this.campusRepository.save(newCampus);
@@ -45,26 +45,26 @@ export class CampusesService {
     return this.campusRepository.find();
   }
 
-  findOne(uuidCampus: string) {
-    if (!uuidCampus) {
-      throw new NotFoundException('UUID du campus manquant');
+  findOne(idCampus: string) {
+    if (!idCampus) {
+      throw new NotFoundException('id du campus manquant');
     }
-    return this.campusRepository.findOneBy({ uuidCampus });
+    return this.campusRepository.findOneBy({ idCampus });
   }
 
-  async update(uuidCampus: string, updateCampusDto: UpdateCampusDto) {
-    const campus = await this.campusRepository.findOneBy({ uuidCampus });
+  async update(idCampus: string, updateCampusDto: UpdateCampusDto) {
+    const campus = await this.campusRepository.findOneBy({ idCampus });
     if (!campus) {
-      throw new NotFoundException(`Campus with UUID "${uuidCampus}" not found`);
+      throw new NotFoundException(`Campus with id "${idCampus}" not found`);
     }
     Object.assign(campus, updateCampusDto);
     return this.campusRepository.save(campus);
   }
 
-  remove(uuidCampus: string) {
-    if (!uuidCampus) {
-      throw new NotFoundException(`Campus with UUID "${uuidCampus}" not found`);
+  remove(idCampus: string) {
+    if (!idCampus) {
+      throw new NotFoundException(`Campus with id "${idCampus}" not found`);
     }
-    return this.campusRepository.delete({ uuidCampus });
+    return this.campusRepository.delete({ idCampus });
   }
 }

--- a/src/campuses/dto/create-campus.dto.ts
+++ b/src/campuses/dto/create-campus.dto.ts
@@ -1,10 +1,31 @@
-import { IntersectionType, PickType } from '@nestjs/swagger';
+import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
 import { PickableDtoFields } from 'src/utils/pickable-dto-fields';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
+import { IsNotEmpty, Length, Matches } from 'class-validator';
+import { IsString } from 'class-validator';
 
-export class CreateCampusDto extends PickType(IntersectionType(PickableDtoFields, PickableDiscordUUIDFields), [
+export class CreateCampusDto extends PickType(IntersectionType(PickableDtoFields, PickableDiscordIdFields), [
+  'idCampus',
   'name',
-  'uuidRole',
-  'uuidGuild'
+  'idRole',
+  'idGuild',
+  'idCategory'
 ]) { 
+  @ApiProperty({
+    description: 'Emplacement du campus',
+    example: 'Lille',
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Length(1, 50)
+  name: string;
+
+  @ApiProperty({
+    description: 'ID Discord de la catégorie associée',
+    example: '123456789012345678'
+  })
+  @IsNotEmpty()
+  @IsString()
+  @Matches(/^\d{17,19}$/)
+  idCategory: string;
 }

--- a/src/campuses/entities/campus.entity.ts
+++ b/src/campuses/entities/campus.entity.ts
@@ -1,18 +1,18 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, OneToOne, ManyToOne, JoinColumn, OneToMany } from 'typeorm';
+import { Entity, Column, PrimaryColumn, CreateDateColumn, UpdateDateColumn, OneToOne, ManyToOne, JoinColumn, OneToMany } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Guild } from '../../guilds/entities/guild.entity';
 import { Role } from 'src/roles/entities/role.entity';
 import { Promotion } from 'src/promotions/entities/promotion.entity';
-
+import { Category } from 'src/categories/entities/category.entity';
 
 @Entity('Campuses')
 export class Campus {
   @ApiProperty({
-    description: 'UUID unique du campus',
-    example: '123e4567-e89b-12d3-a456-426614174000'
+    description: 'SF unique du campus',
+    example: '123456789012345678'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_campus' })
-  uuidCampus: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_campus' })
+  idCampus: string;
 
   @ApiProperty({
     description: 'Nom du campus',
@@ -23,11 +23,18 @@ export class Campus {
   name: string;
 
   @ApiProperty({
-    description: 'UUID Discord du serveur associé',
+    description: 'id Discord du serveur associé',
     example: '123456789012345678'
   })
-  @Column({ name: 'uuid_guild', type: 'varchar', length: 19 })
-  uuidGuild: string;
+  @Column({ name: 'id_guild', type: 'varchar', length: 19 })
+  idGuild: string;
+
+  @ApiProperty({
+    description: 'id Discord de la catégorie associée',
+    example: '123456789012345678'
+  })
+  @Column({ name: 'id_category', type: 'varchar', length: 19 })
+  idCategory: string;
 
   @ApiProperty({
     description: 'Date de création'
@@ -46,14 +53,14 @@ export class Campus {
     type: () => Guild
   })
   @ManyToOne(() => Guild, guild => guild.campuses)
-  @JoinColumn({ name: 'uuid_guild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 
-  @Column({ type: 'varchar', name: 'uuid_role' })
-  uuidRole: string;
+  @Column({ type: 'varchar', name: 'id_role' })
+  idRole: string;
 
   @OneToOne(() => Role, role => role.campus)
-  @JoinColumn({ name: 'uuid_role' })
+  @JoinColumn({ name: 'id_role' })
   role: Role
 
   @ApiProperty({
@@ -62,4 +69,12 @@ export class Campus {
   })
   @OneToMany(() => Promotion, promotion => promotion.campus)
   promotions: Promotion[];
+
+  @ApiProperty({
+    description: 'La catégorie associée au campus',
+    type: () => Category
+  })
+  @ManyToOne(() => Category, category => category.campuses)
+  @JoinColumn({ name: 'id_category' })
+  category: Category;
 }

--- a/src/categories/categories.controller.spec.ts
+++ b/src/categories/categories.controller.spec.ts
@@ -25,10 +25,10 @@ describe('CategoriesController', () => {
 
   it('should create a new category', async () => {
     const dto: CreateCategoryDto = {
-      uuid: '123456789012345678',
-      uuidGuild: '987654321098765432',
+      idCategory: '123456789012345678',
+      idGuild: '987654321098765432',
       name: 'Test Category',
-      position: 1,
+      categoryPosition: 1,
     };
     const result = { ...dto };
     mockCategoriesService.create.mockResolvedValue(result);
@@ -37,22 +37,22 @@ describe('CategoriesController', () => {
   });
 
   it('should return an array of categories', async () => {
-    const result = [{ uuid: '123456789012345678', uuidGuild: '987654321098765432', name: 'Test Category', position: 1 }];
+    const result = [{ idCategory: '123456789012345678', idGuild: '987654321098765432', name: 'Test Category', categoryPosition: 1 }];
     mockCategoriesService.findAll.mockResolvedValue(result);
     expect(await controller.findAll()).toEqual(result);
     expect(mockCategoriesService.findAll).toHaveBeenCalled();
   });
 
   it('should return a single category', async () => {
-    const result = { uuid: '123456789012345678', uuidGuild: '987654321098765432', name: 'Test Category', position: 1 };
+    const result = { idCategory: '123456789012345678', idGuild: '987654321098765432', name: 'Test Category', categoryPosition: 1 };
     mockCategoriesService.findOne.mockResolvedValue(result);
     expect(await controller.findOne('123456789012345678')).toEqual(result);
     expect(mockCategoriesService.findOne).toHaveBeenCalledWith('123456789012345678');
   });
 
   it('should update a category', async () => {
-    const dto: UpdateCategoryDto = { name: 'Updated Category', position: 2 };
-    const result = { uuid: '123456789012345678', uuidGuild: '987654321098765432', name: 'Updated Category', position: 2 };
+    const dto: UpdateCategoryDto = { name: 'Updated Category', categoryPosition: 2 };
+    const result = { idCategory: '123456789012345678', idGuild: '987654321098765432', name: 'Updated Category', categoryPosition: 2 };
     mockCategoriesService.update.mockResolvedValue(result);
     expect(await controller.update('123456789012345678', dto)).toEqual(result);
     expect(mockCategoriesService.update).toHaveBeenCalledWith('123456789012345678', dto);

--- a/src/categories/categories.controller.ts
+++ b/src/categories/categories.controller.ts
@@ -25,31 +25,31 @@ export class CategoriesController {
     return this.categoriesService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer une catégorie par son UUID' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer une catégorie par son id' })
   @ApiResponse({ status: 200, description: 'La catégorie a été trouvée.', type: Category })
   @ApiResponse({ status: 404, description: 'Catégorie non trouvée' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.categoriesService.findOne(uuid);
+  findOne(@Param('id') idCategory: string) {
+    return this.categoriesService.findOne(idCategory);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour une catégorie' })
   @ApiResponse({ status: 200, description: 'La catégorie a été mise à jour avec succès.', type: Category })
   @ApiResponse({ status: 404, description: 'Catégorie non trouvée' })
-  async update(@Param('uuid') uuid: string, @Body() updateCategoryDto: UpdateCategoryDto) {
-    const category = await this.categoriesService.update(uuid, updateCategoryDto);
+  async update(@Param('id') idCategory: string, @Body() updateCategoryDto: UpdateCategoryDto) {
+    const category = await this.categoriesService.update(idCategory, updateCategoryDto);
     if (!category) {
-      throw new NotFoundException(`Category with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Category with id "${idCategory}" not found`);
     }
     return category;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer une catégorie' })
   @ApiResponse({ status: 200, description: 'La catégorie a été supprimée avec succès.' })
   @ApiResponse({ status: 404, description: 'Catégorie non trouvée' })
-  remove(@Param('uuid') uuid: string) {
-    return this.categoriesService.remove(uuid);
+  remove(@Param('id') idCategory: string) {
+    return this.categoriesService.remove(idCategory);
   }
 }

--- a/src/categories/categories.service.spec.ts
+++ b/src/categories/categories.service.spec.ts
@@ -27,10 +27,10 @@ describe('CategoriesService', () => {
 
   it('should create a new category', async () => {
     const dto: CreateCategoryDto = {
-      uuid: '123456789012345678',
-      uuidGuild: '987654321098765432',
+      idCategory: '123456789012345678',
+      idGuild: '987654321098765432',
       name: 'Test Category',
-      position: 1,
+      categoryPosition: 1,
     };
     const entity = { ...dto };
     mockRepository.create.mockReturnValue(entity);
@@ -42,14 +42,14 @@ describe('CategoriesService', () => {
   });
 
   it('should return an array of categories', async () => {
-    const result = [{ uuid: '123456789012345678', uuidGuild: '987654321098765432', name: 'Test Category', position: 1 }];
+    const result = [{ idCategory: '123456789012345678', idGuild: '987654321098765432', name: 'Test Category', categoryPosition: 1 }];
     mockRepository.find.mockResolvedValue(result);
     expect(await service.findAll()).toEqual(result);
     expect(mockRepository.find).toHaveBeenCalledWith({
       relations: {
         guild: true,
         channels: true,
-        course: true,
+        courses: true,
         promotion: true,
         guildTemplate: true
       }
@@ -57,15 +57,15 @@ describe('CategoriesService', () => {
   });
 
   it('should return a single category', async () => {
-    const result = { uuid: '123456789012345678', uuidGuild: '987654321098765432', name: 'Test Category', position: 1 };
+    const result = { idCategory: '123456789012345678', idGuild: '987654321098765432', name: 'Test Category', categoryPosition: 1 };
     mockRepository.findOne.mockResolvedValue(result);
     expect(await service.findOne('123456789012345678')).toEqual(result);
     expect(mockRepository.findOne).toHaveBeenCalledWith({
-      where: { uuid: '123456789012345678' },
+      where: { idCategory: '123456789012345678' },
       relations: {
         guild: true,
         channels: true,
-        course: true,
+        courses: true,
         promotion: true,
         guildTemplate: true
       }
@@ -73,19 +73,19 @@ describe('CategoriesService', () => {
   });
 
   it('should update a category', async () => {
-    const dto: UpdateCategoryDto = { name: 'Updated Category', position: 2 };
-    const result = { uuid: '123456789012345678', uuidGuild: '987654321098765432', name: 'Updated Category', position: 2 };
+    const dto: UpdateCategoryDto = { name: 'Updated Category', categoryPosition: 2 };
+    const result = { idCategory: '123456789012345678', idGuild: '987654321098765432', name: 'Updated Category', categoryPosition: 2 };
     mockRepository.findOneBy.mockResolvedValue(result);
     mockRepository.save.mockResolvedValue(result);
 
     expect(await service.update('123456789012345678', dto)).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: '123456789012345678' });
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idCategory: '123456789012345678' });
     expect(mockRepository.save).toHaveBeenCalledWith(result);
   });
 
   it('should delete a category', async () => {
     mockRepository.delete.mockResolvedValue({ affected: 1 });
     expect(await service.remove('123456789012345678')).toEqual({ affected: 1 });
-    expect(mockRepository.delete).toHaveBeenCalledWith({ uuid: '123456789012345678' });
+    expect(mockRepository.delete).toHaveBeenCalledWith({ idCategory: '123456789012345678' });
   });
 });

--- a/src/categories/categories.service.ts
+++ b/src/categories/categories.service.ts
@@ -26,43 +26,43 @@ export class CategoriesService {
       relations: {
         guild: true,
         channels: true,
-        course: true,
+        courses: true,
         promotion: true,
         guildTemplate: true
       }
     });
   }
 
-  findOne(uuid: string) {
+  findOne(idCategory: string) {
     return this.categoryRepository.findOne({
-      where: { uuid },
+      where: { idCategory },
       relations: {
         guild: true,
         channels: true,
-        course: true,
+        courses: true,
         promotion: true,
         guildTemplate: true
       }
     });
   }
 
-  async update(uuid: string, updateCategoryDto: UpdateCategoryDto) {
-    const category = await this.categoryRepository.findOneBy({ uuid });
+  async update(idCategory: string, updateCategoryDto: UpdateCategoryDto) {
+    const category = await this.categoryRepository.findOneBy({ idCategory });
     if (!category) {
       return null;
     }
     
     // Mise à jour des champs autorisés uniquement
-    const { name, position, uuidGuildTemplate } = updateCategoryDto;
+    const { name, categoryPosition, idGuildTemplate } = updateCategoryDto;
     if (name !== undefined) category.name = name;
-    if (position !== undefined) category.position = position;
-    if (uuidGuildTemplate !== undefined) category.uuidGuildTemplate = uuidGuildTemplate;
+    if (categoryPosition !== undefined) category.categoryPosition = categoryPosition;
+    if (idGuildTemplate !== undefined) category.idGuildTemplate = idGuildTemplate;
     
     category.updatedAt = new Date();
     return this.categoryRepository.save(category);
   }
 
-  remove(uuid: string) {
-    return this.categoryRepository.delete({ uuid });
+  remove(idCategory: string) {
+    return this.categoryRepository.delete({ idCategory });
   }
 }

--- a/src/categories/dto/create-category.dto.ts
+++ b/src/categories/dto/create-category.dto.ts
@@ -1,23 +1,11 @@
 import { IsString, IsInt, MaxLength, Min, Length } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty, PickType } from '@nestjs/swagger';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
 
-export class CreateCategoryDto {
-    @ApiProperty({
-        description: 'ID Discord de la catégorie',
-        example: '123456789012345678'
-    })
-    @IsString()
-    @Length(17, 19)
-    uuid: string;
-
-    @ApiProperty({
-        description: 'ID Discord du serveur',
-        example: '123456789012345678'
-    })
-    @IsString()
-    @Length(17, 19)
-    uuidGuild: string;
-
+export class CreateCategoryDto extends PickType(PickableDiscordIdFields, [
+    'idCategory',
+    'idGuild'
+]) {
     @ApiProperty({
         description: 'Nom de la catégorie',
         example: 'Général'
@@ -32,5 +20,5 @@ export class CreateCategoryDto {
     })
     @IsInt()
     @Min(0)
-    position: number;
+    categoryPosition: number;
 }

--- a/src/categories/dto/update-category.dto.ts
+++ b/src/categories/dto/update-category.dto.ts
@@ -4,7 +4,7 @@ import { IsOptional, IsString, Length } from 'class-validator';
 import { ApiProperty } from '@nestjs/swagger';
 
 export class UpdateCategoryDto extends PartialType(
-  OmitType(CreateCategoryDto, ['uuid', 'uuidGuild'] as const),
+  OmitType(CreateCategoryDto, ['idCategory', 'idGuild'] as const),
 ) {
   @ApiProperty({
     description: 'ID Discord du template de serveur associé',
@@ -14,5 +14,5 @@ export class UpdateCategoryDto extends PartialType(
   @IsString()
   @Length(17, 19)
   @IsOptional()
-  uuidGuildTemplate?: string;
+  idGuildTemplate?: string;
 }

--- a/src/categories/entities/category.entity.ts
+++ b/src/categories/entities/category.entity.ts
@@ -5,15 +5,16 @@ import { Guild } from '../../guilds/entities/guild.entity';
 import { Course } from '../../courses/entities/course.entity';
 import { Promotion } from 'src/promotions/entities/promotion.entity';
 import { GuildTemplate } from 'src/guilds-templates/entities/guild-template.entity';
+import { Campus } from '../../campuses/entities/campus.entity';
 
 @Entity('categories')
 export class Category {
   @ApiProperty({
-    description: 'ID Discord de la catégorie',
+    description: 'SF Discord de la catégorie',
     example: '123456789012345678'
   })
-  @PrimaryColumn({ type: 'varchar', length: 19, name: 'uuid_category' })
-  uuid: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_category' })
+  idCategory: string;
 
   @ApiProperty({
     description: 'Le nom de la catégorie',
@@ -27,15 +28,15 @@ export class Category {
     description: 'La position de la catégorie',
     example: 1
   })
-  @Column({ type: 'int' })
-  position: number;
+  @Column({ type: 'int', name: 'category_position' })
+  categoryPosition: number;
 
   @ApiProperty({
     description: 'ID Discord du serveur associé',
     example: '123456789012345678'
   })
-  @Column({ name: 'uuidGuild', type: 'varchar', length: 19 })
-  uuidGuild: string;
+  @Column({ name: 'id_guild', type: 'varchar', length: 19 })
+  idGuild: string;
 
   @ApiProperty({
     description: 'Date de création'
@@ -65,18 +66,18 @@ export class Category {
   channels: Channel[];
 
   @ApiProperty({
-    description: 'Formation associée à la catégorie',
-    type: () => Course
+    description: 'Formations associées à la catégorie',
+    type: () => [Course]
   })
   @OneToMany(() => Course, course => course.category)
-  course: Course[];
+  courses: Course[]; 
 
   @ApiProperty({
     description: 'Le serveur Discord associé à cette catégorie',
     type: () => Guild
   })
   @ManyToOne(() => Guild, guild => guild.categories)
-  @JoinColumn({ name: 'uuidGuild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 
   @ApiProperty({
@@ -91,14 +92,22 @@ export class Category {
     example: '123456789012345678',
     required: false
   })
-  @Column({ name: 'uuid_guild_template', type: 'varchar', length: 19, nullable: true })
-  uuidGuildTemplate: string;
+  @Column({ name: 'id_guild_template', type: 'varchar', length: 19, nullable: true })
+  idGuildTemplate: string;
 
   @ApiProperty({
     description: 'Template de serveur associé à cette catégorie',
     type: () => GuildTemplate
   })
   @OneToOne(() => GuildTemplate, guildTemplate => guildTemplate.category)
-  @JoinColumn({ name: 'uuid_guild_template' })
+  @JoinColumn({ name: 'id_guild_template' })
   guildTemplate: GuildTemplate;
+
+  @ApiProperty({
+    description: 'Liste des campus dans cette catégorie',
+    type: () => Campus,
+    isArray: true
+  })
+  @OneToMany(() => Campus, campus => campus.category)
+  campuses: Campus[];
 }

--- a/src/channels/channels.controller.ts
+++ b/src/channels/channels.controller.ts
@@ -25,35 +25,35 @@ export class ChannelsController {
     return this.channelService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer un channel par son UUID' })
-  @ApiParam({ name: 'uuid', description: 'UUID du channel' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer un channel par son id' })
+  @ApiParam({ name: 'id', description: 'id du channel' })
   @ApiResponse({ status: 200, description: 'Le channel a été trouvé.', type: Channel })
   @ApiResponse({ status: 404, description: 'Channel non trouvé' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.channelService.findOne(uuid);
+  findOne(@Param('id') idChannel: string) {
+    return this.channelService.findOne(idChannel);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour un channel' })
-  @ApiParam({ name: 'uuid', description: 'UUID du channel' })
+  @ApiParam({ name: 'id', description: 'id du channel' })
   @ApiResponse({ status: 200, description: 'Le channel a été mis à jour.', type: Channel })
   @ApiResponse({ status: 404, description: 'Channel non trouvé' })
   @ApiResponse({ status: 400, description: 'Requête invalide' })
-  async update(@Param('uuid') uuid: string, @Body() updateChannelDto: UpdateChannelDto) {
-    const channel = await this.channelService.update(uuid, updateChannelDto);
+  async update(@Param('id') idChannel: string, @Body() updateChannelDto: UpdateChannelDto) {
+    const channel = await this.channelService.update(idChannel, updateChannelDto);
     if (!channel) {
-      throw new NotFoundException(`Channel with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Channel with id "${idChannel}" not found`);
     }
     return channel;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer un channel' })
-  @ApiParam({ name: 'uuid', description: 'UUID du channel' })
+  @ApiParam({ name: 'id', description: 'id du channel' })
   @ApiResponse({ status: 200, description: 'Le channel a été supprimé.' })
   @ApiResponse({ status: 404, description: 'Channel non trouvé' })
-  remove(@Param('uuid') uuid: string) {
-    return this.channelService.remove(uuid);
+  remove(@Param('id') idChannel: string) {
+    return this.channelService.remove(idChannel);
   }
 } 

--- a/src/channels/channels.service.spec.ts
+++ b/src/channels/channels.service.spec.ts
@@ -2,24 +2,64 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { ChannelsService } from './channels.service';
 import { Channel } from './entities/channel.entity';
 import { Repository } from 'typeorm';
-import { NotFoundException } from '@nestjs/common';
+import { Guild } from '../guilds/entities/guild.entity';
+import { Category } from '../categories/entities/category.entity';
+import { Course } from '../courses/entities/course.entity';
+import { Role } from '../roles/entities/role.entity';
 
 describe('ChannelsService', () => {
   let service: ChannelsService;
   let repository: Repository<Channel>;
 
-  const mockChannel: Channel = {
-    uuid: '123456789012345678',
+  const mockGuild: Partial<Guild> = {
+    idGuild: '345678901234567890',
+    name: 'test-guild',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    channels: [],
+    categories: [],
+    courses: [],
+    roles: []
+  };
+
+  const mockCategory: Partial<Category> = {
+    idCategory: '234567890123456789',
+    name: 'test-category',
+    categoryPosition: 1,
+    idGuild: '345678901234567890',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    channels: [],
+    guild: mockGuild as Guild
+  };
+
+  const mockCourse: Partial<Course> = {
+    idCourse: '456789012345678901',
+    name: 'test-course',
+    isCertified: true,
+    idCategory: '234567890123456789',
+    idGuild: '345678901234567890',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+    category: mockCategory as Category,
+    guild: mockGuild as Guild,
+    channels: [],
+    promotions: []
+  };
+
+  const mockChannel: Partial<Channel> = {
+    idChannel: '123456789012345678',
     name: 'test-channel',
     type: 'text',
     channelPosition: 1,
-    uuidCategory: '234567890123456789',
-    uuidGuild: '345678901234567890',
+    idCategory: '234567890123456789',
+    idGuild: '345678901234567890',
+    idCourse: '456789012345678901',
     createdAt: new Date(),
     updatedAt: new Date(),
-    category: null,
-    course: null,
-    guild: null
+    category: mockCategory as Category,
+    course: mockCourse as Course,
+    guild: mockGuild as Guild
   };
 
   const mockRepository = {
@@ -44,28 +84,35 @@ describe('ChannelsService', () => {
   describe('create', () => {
     it('devrait créer un nouveau channel', async () => {
       const createChannelDto = {
-        uuid: '123456789012345678',
+        idChannel: '123456789012345678',
         name: 'test-channel',
         type: 'text',
         channelPosition: 1,
-        uuidCategory: '234567890123456789',
-        uuidGuild: '345678901234567890'
+        idCategory: '234567890123456789',
+        idGuild: '345678901234567890'
       };
 
-      mockRepository.create.mockReturnValue(mockChannel);
-      mockRepository.save.mockResolvedValue(mockChannel);
+      const simpleChannel = {
+        ...createChannelDto,
+        idCourse: '456789012345678901',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
+
+      mockRepository.create.mockReturnValue(simpleChannel);
+      mockRepository.save.mockResolvedValue(simpleChannel);
 
       const result = await service.create(createChannelDto);
 
-      expect(result).toEqual(mockChannel);
+      expect(result).toEqual(simpleChannel);
       expect(mockRepository.create).toHaveBeenCalledWith(createChannelDto);
-      expect(mockRepository.save).toHaveBeenCalledWith(mockChannel);
+      expect(mockRepository.save).toHaveBeenCalledWith(simpleChannel);
     });
   });
 
   describe('findAll', () => {
     it('devrait retourner un tableau de channels', async () => {
-      const channels = [mockChannel];
+      const channels = [mockChannel as Channel];
       mockRepository.find.mockResolvedValue(channels);
 
       const result = await service.findAll();
@@ -78,14 +125,14 @@ describe('ChannelsService', () => {
   });
 
   describe('findOne', () => {
-    it('devrait retourner un channel par son uuid', async () => {
-      mockRepository.findOne.mockResolvedValue(mockChannel);
+    it('devrait retourner un channel par son id avec ses relations', async () => {
+      mockRepository.findOne.mockResolvedValue(mockChannel as Channel);
 
-      const result = await service.findOne(mockChannel.uuid);
+      const result = await service.findOne(mockChannel.idChannel as string);
 
       expect(result).toEqual(mockChannel);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: mockChannel.uuid },
+        where: { idChannel: mockChannel.idChannel as string },
         relations: ['guild', 'category']
       });
     });
@@ -103,20 +150,20 @@ describe('ChannelsService', () => {
       mockRepository.findOneBy.mockResolvedValue(mockChannel);
       mockRepository.save.mockResolvedValue(updatedChannel);
 
-      const result = await service.update(mockChannel.uuid, updateChannelDto);
+      const result = await service.update(mockChannel.idChannel as string, updateChannelDto);
 
       expect(result).toEqual(updatedChannel);
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: mockChannel.uuid });
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idChannel: mockChannel.idChannel as string });
       expect(mockRepository.save).toHaveBeenCalled();
     });
 
     it('devrait retourner null si le channel à mettre à jour n\'existe pas', async () => {
       mockRepository.findOneBy.mockResolvedValue(null);
 
-      const result = await service.update('non-existent-uuid', {});
+      const result = await service.update('non-existent-id' as string, {});
 
       expect(result).toBeNull();
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: 'non-existent-uuid' });
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idChannel: 'non-existent-id' as string });
       expect(mockRepository.save).not.toHaveBeenCalled();
     });
   });
@@ -125,9 +172,9 @@ describe('ChannelsService', () => {
     it('devrait supprimer un channel', async () => {
       mockRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.remove(mockChannel.uuid);
+      await service.remove(mockChannel.idChannel as string);
 
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuid: mockChannel.uuid });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idChannel: mockChannel.idChannel as string });
     });
   });
 }); 

--- a/src/channels/channels.service.ts
+++ b/src/channels/channels.service.ts
@@ -23,31 +23,31 @@ export class ChannelsService {
     });
   }
 
-  findOne(uuid: string) {
+  findOne(idChannel: string) {
     return this.channelRepository.findOne({
-      where: { uuid },
+      where: { idChannel },
       relations: ['guild', 'category']
     });
   }
 
-  async update(uuid: string, updateChannelDto: UpdateChannelDto) {
-    const channel = await this.channelRepository.findOneBy({ uuid });
+  async update(idChannel: string, updateChannelDto: UpdateChannelDto) {
+    const channel = await this.channelRepository.findOneBy({ idChannel });
     if (!channel) {
       return null;
     }
     
     // Mise à jour des champs autorisés uniquement
-    const { name, type, channelPosition, uuidCategory } = updateChannelDto;
+    const { name, type, channelPosition, idCategory } = updateChannelDto;
     if (name !== undefined) channel.name = name;
     if (type !== undefined) channel.type = type;
     if (channelPosition !== undefined) channel.channelPosition = channelPosition;
-    if (uuidCategory !== undefined) channel.uuidCategory = uuidCategory;
+    if (idCategory !== undefined) channel.idCategory = idCategory;
     
     channel.updatedAt = new Date();
     return this.channelRepository.save(channel);
   }
 
-  remove(uuid: string) {
-    return this.channelRepository.delete({ uuid });
+  remove(idChannel: string) {
+    return this.channelRepository.delete({ idChannel });
   }
 } 

--- a/src/channels/dto/create-channel.dto.ts
+++ b/src/channels/dto/create-channel.dto.ts
@@ -1,6 +1,6 @@
 import { IsString, IsInt, IsEnum, MaxLength, Min, Length } from 'class-validator';
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
 
 enum ChannelType {
   TEXT = 'text',
@@ -8,18 +8,11 @@ enum ChannelType {
   ANNOUNCEMENT = 'announcement'
 }
 
-export class CreateChannelDto extends PickType(PickableDiscordUUIDFields, [
-  'uuidGuild',
-  'uuidCategory'
+export class CreateChannelDto extends PickType(PickableDiscordIdFields, [
+  'idChannel',
+  'idGuild',
+  'idCategory'
 ]) {
-  @ApiProperty({
-    description: 'ID Discord du channel',
-    example: '123456789012345678'
-  })
-  @IsString()
-  @Length(17, 19)
-  uuid: string;
-
   @ApiProperty({
     description: 'Le nom du channel',
     example: 'général',
@@ -47,6 +40,6 @@ export class CreateChannelDto extends PickType(PickableDiscordUUIDFields, [
   @Min(0)
   channelPosition: number;
 
-  uuidGuild: string;
-  uuidCategory: string;
+  idGuild: string;
+  idCategory: string;
 } 

--- a/src/channels/dto/update-channel.dto.ts
+++ b/src/channels/dto/update-channel.dto.ts
@@ -2,5 +2,5 @@ import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateChannelDto } from './create-channel.dto';
 
 export class UpdateChannelDto extends PartialType(
-  OmitType(CreateChannelDto, ['uuid'] as const),
+  OmitType(CreateChannelDto, ['idChannel'] as const),
 ) {} 

--- a/src/channels/entities/channel.entity.ts
+++ b/src/channels/entities/channel.entity.ts
@@ -7,11 +7,11 @@ import { Guild } from '../../guilds/entities/guild.entity';
 @Entity('Channels')
 export class Channel {
   @ApiProperty({
-    description: 'ID Discord du channel',
+    description: 'SF Discord du channel',
     example: '123456789012345678'
   })
-  @PrimaryColumn({ type: 'varchar', length: 19 , name: 'uuid_channel' })
-  uuid: string;
+  @PrimaryColumn({ type: 'varchar', length: 19 , name: 'id_channel' })
+  idChannel: string;
 
   @ApiProperty({
     description: 'Le nom du channel',
@@ -41,15 +41,23 @@ export class Channel {
     example: '123456789012345678',
     required: false
   })
-  @Column({ name: 'uuid_category', type: 'varchar', length: 19, nullable: true })
-  uuidCategory: string;
+  @Column({ name: 'id_category', type: 'varchar', length: 19, nullable: true })
+  idCategory: string;
 
   @ApiProperty({
     description: 'ID Discord du serveur associé',
     example: '123456789012345678'
   })
-  @Column({ name: 'uuid_guild', type: 'varchar', length: 19 })
-  uuidGuild: string;
+  @Column({ name: 'id_guild', type: 'varchar', length: 19 })
+  idGuild: string;
+
+  @ApiProperty({
+    description: 'ID de la formation associée',
+    example: '123456789012345678',
+    required: false
+  })
+  @Column({ name: 'id_course', type: 'varchar', length: 19, nullable: true })
+  idCourse: string;
 
   @ApiProperty({
     description: 'Date de création'
@@ -72,8 +80,8 @@ export class Channel {
     onDelete: 'SET NULL',
     nullable: true
   })
-  @JoinColumn({ name: 'uuid_category' })
-  category: Category;
+  @JoinColumn({ name: 'id_category' })
+  category?: Category;
 
   @ApiProperty({
     description: 'Formation associées aux channels',
@@ -81,14 +89,14 @@ export class Channel {
     isArray: true
   })
   @ManyToOne(() => Course, course => course.channels)
-  @JoinColumn({ name: 'uuid_course' })
-  course: Course;
+  @JoinColumn({ name: 'id_course' })
+  course?: Course;
 
   @ApiProperty({
     description: 'Le serveur Discord associé au channel',
     type: () => Guild
   })
   @ManyToOne(() => Guild, guild => guild.channels)
-  @JoinColumn({ name: 'uuid_guild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 } 

--- a/src/comments/comments.controller.spec.ts
+++ b/src/comments/comments.controller.spec.ts
@@ -12,19 +12,19 @@ describe('CommentsController', () => {
   let service: CommentsService;
 
   const mockComment = {
-    uuidComment: '123e4567-e89b-12d3-a456-426614174000',
+    idComment: '123e4567-e89b-12d3-a456-426614174000',
     content: 'Test comment',
     status: 'active',
     createdAt: new Date(),
-    uuidMember: '123e4567-e89b-12d3-a456-426614174001',
-    uuidResource: '123e4567-e89b-12d3-a456-426614174002'
+    idMember: '123e4567-e89b-12d3-a456-426614174001',
+    idResource: '123e4567-e89b-12d3-a456-426614174002'
   } as Comment;
 
   const mockCreateDto: CreateCommentDto = {
     content: 'Test comment',
     status: 'active',
-    uuidMember: '123e4567-e89b-12d3-a456-426614174001',
-    uuidResource: '123e4567-e89b-12d3-a456-426614174002'
+    idMember: '123e4567-e89b-12d3-a456-426614174001',
+    idResource: '123e4567-e89b-12d3-a456-426614174002'
   };
 
   const mockUpdateDto: UpdateCommentDto = {
@@ -82,8 +82,8 @@ describe('CommentsController', () => {
       await expect(controller.create(invalidDto)).rejects.toThrow(BadRequestException);
     });
 
-    it('devrait rejeter un commentaire avec un UUID membre invalide', async () => {
-      const invalidDto = { ...mockCreateDto, uuidMember: 'invalid-uuid' };
+    it('devrait rejeter un commentaire avec un id membre invalide', async () => {
+      const invalidDto = { ...mockCreateDto, idMember: 'invalid-uuid' };
       vi.spyOn(service, 'create').mockRejectedValueOnce(new BadRequestException());
 
       await expect(controller.create(invalidDto)).rejects.toThrow(BadRequestException);
@@ -111,7 +111,7 @@ describe('CommentsController', () => {
     it('devrait retourner les commentaires triés par date de création', async () => {
       const mockComments = [
         { ...mockComment, createdAt: new Date('2024-03-01') },
-        { ...mockComment, uuidComment: '456', createdAt: new Date('2024-03-02') }
+        { ...mockComment, idComment: '456', createdAt: new Date('2024-03-02') }
       ];
       vi.spyOn(service, 'findAll').mockResolvedValueOnce(mockComments);
 
@@ -125,10 +125,10 @@ describe('CommentsController', () => {
 
   describe('findOne', () => {
     it('devrait retourner un commentaire par uuid', async () => {
-      const result = await controller.findOne(mockComment.uuidComment);
+      const result = await controller.findOne(mockComment.idComment);
 
       expect(result).toEqual(mockComment);
-      expect(service.findOne).toHaveBeenCalledWith(mockComment.uuidComment);
+      expect(service.findOne).toHaveBeenCalledWith(mockComment.idComment);
       expect(service.findOne).toHaveBeenCalledTimes(1);
     });
 
@@ -138,7 +138,7 @@ describe('CommentsController', () => {
       await expect(controller.findOne('non-existant')).rejects.toThrow(NotFoundException);
     });
 
-    it('devrait rejeter un UUID invalide', async () => {
+    it('devrait rejeter un id invalide', async () => {
       vi.spyOn(service, 'findOne').mockRejectedValueOnce(new BadRequestException());
 
       await expect(controller.findOne('invalid-uuid')).rejects.toThrow();
@@ -150,10 +150,10 @@ describe('CommentsController', () => {
       const updatedComment = { ...mockComment, ...mockUpdateDto } as Comment;
       vi.spyOn(service, 'update').mockResolvedValueOnce(updatedComment);
 
-      const result = await controller.update(mockComment.uuidComment, mockUpdateDto);
+      const result = await controller.update(mockComment.idComment, mockUpdateDto);
 
       expect(result).toEqual(updatedComment);
-      expect(service.update).toHaveBeenCalledWith(mockComment.uuidComment, mockUpdateDto);
+      expect(service.update).toHaveBeenCalledWith(mockComment.idComment, mockUpdateDto);
       expect(service.update).toHaveBeenCalledTimes(1);
     });
 
@@ -168,7 +168,7 @@ describe('CommentsController', () => {
       const updatedComment = { ...mockComment, ...partialUpdate } as Comment;
       vi.spyOn(service, 'update').mockResolvedValueOnce(updatedComment);
 
-      const result = await controller.update(mockComment.uuidComment, partialUpdate);
+      const result = await controller.update(mockComment.idComment, partialUpdate);
 
       expect(result.content).toBe(partialUpdate.content);
       expect(result.status).toBe(mockComment.status);
@@ -178,15 +178,15 @@ describe('CommentsController', () => {
       const invalidUpdate = { status: 'invalid_status' };
       vi.spyOn(service, 'update').mockRejectedValueOnce(new BadRequestException());
 
-      await expect(controller.update(mockComment.uuidComment, invalidUpdate)).rejects.toThrow(BadRequestException);
+      await expect(controller.update(mockComment.idComment, invalidUpdate)).rejects.toThrow(BadRequestException);
     });
   });
 
   describe('remove', () => {
     it('devrait supprimer un commentaire', async () => {
-      await controller.remove(mockComment.uuidComment);
+      await controller.remove(mockComment.idComment);
 
-      expect(service.remove).toHaveBeenCalledWith(mockComment.uuidComment);
+      expect(service.remove).toHaveBeenCalledWith(mockComment.idComment);
       expect(service.remove).toHaveBeenCalledTimes(1);
     });
 
@@ -196,17 +196,17 @@ describe('CommentsController', () => {
       await expect(controller.remove('non-existant')).rejects.toThrow(NotFoundException);
     });
 
-    it('devrait rejeter un UUID invalide', async () => {
+    it('devrait rejeter un id invalide', async () => {
       vi.spyOn(service, 'remove').mockRejectedValueOnce(new BadRequestException());
 
       await expect(controller.remove('invalid-uuid')).rejects.toThrow();
     });
 
     it('devrait vérifier que le commentaire a bien été supprimé', async () => {
-      await controller.remove(mockComment.uuidComment);
+      await controller.remove(mockComment.idComment);
       
       vi.spyOn(service, 'findOne').mockRejectedValueOnce(new NotFoundException());
-      await expect(service.findOne(mockComment.uuidComment)).rejects.toThrow(NotFoundException);
+      await expect(service.findOne(mockComment.idComment)).rejects.toThrow(NotFoundException);
     });
   });
 }); 

--- a/src/comments/comments.controller.ts
+++ b/src/comments/comments.controller.ts
@@ -27,36 +27,36 @@ export class CommentsController {
     return this.commentsService.findAll();
   }
 
-  @Get(':uuid')
+  @Get(':id')
   @HttpCode(HttpStatus.OK)
-  @ApiOperation({ summary: 'Récupérer un commentaire par UUID' })
-  @ApiParam({ name: 'uuid', description: 'UUID du commentaire' })
+  @ApiOperation({ summary: 'Récupérer un commentaire par id' })
+  @ApiParam({ name: 'id', description: 'id du commentaire' })
   @ApiResponse({ status: 200, type: Comment })
   @ApiResponse({ status: 404, description: 'Non trouvé' })
-  findOne(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<Comment> {
-    return this.commentsService.findOne(uuid);
+  findOne(@Param('id', ParseUUIDPipe) idComment: string): Promise<Comment> {
+    return this.commentsService.findOne(idComment);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ summary: 'Mettre à jour un commentaire' })
-  @ApiParam({ name: 'uuid', description: 'UUID du commentaire' })
+  @ApiParam({ name: 'id', description: 'id du commentaire' })
   @ApiResponse({ status: 200, type: Comment })
   @ApiResponse({ status: 404, description: 'Non trouvé' })
   update(
-    @Param('uuid', ParseUUIDPipe) uuid: string,
+    @Param('id', ParseUUIDPipe) idComment: string,
     @Body() updateCommentDto: UpdateCommentDto
   ): Promise<Comment> {
-    return this.commentsService.update(uuid, updateCommentDto);
+    return this.commentsService.update(idComment, updateCommentDto);
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @HttpCode(HttpStatus.NO_CONTENT)
   @ApiOperation({ summary: 'Supprimer un commentaire' })
-  @ApiParam({ name: 'uuid', description: 'UUID du commentaire' })
+  @ApiParam({ name: 'id', description: 'id du commentaire' })
   @ApiResponse({ status: 204, description: 'Supprimé' })
   @ApiResponse({ status: 404, description: 'Non trouvé' })
-  remove(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<void> {
-    return this.commentsService.remove(uuid);
+  remove(@Param('id', ParseUUIDPipe) idComment: string): Promise<void> {
+    return this.commentsService.remove(idComment);
   }
 }

--- a/src/comments/comments.service.spec.ts
+++ b/src/comments/comments.service.spec.ts
@@ -15,8 +15,8 @@ describe('CommentsService', () => {
   const mockCreateDto: CreateCommentDto = {
     content: 'Test comment',
     status: 'active',
-    uuidMember: '123e4567-e89b-12d3-a456-426614174001',
-    uuidResource: '123e4567-e89b-12d3-a456-426614174002'
+    idMember: '123e4567-e89b-12d3-a456-426614174001',
+    idResource: '123e4567-e89b-12d3-a456-426614174002'
   };
 
   const mockUpdateDto: UpdateCommentDto = {
@@ -25,12 +25,12 @@ describe('CommentsService', () => {
   };
 
   const mockComment = {
-    uuidComment: '123e4567-e89b-12d3-a456-426614174000',
+    idComment: '123e4567-e89b-12d3-a456-426614174000',
     content: 'Test comment',
     status: 'active',
     createdAt: new Date(),
-    uuidMember: '123e4567-e89b-12d3-a456-426614174001',
-    uuidResource: '123e4567-e89b-12d3-a456-426614174002'
+    idMember: '123e4567-e89b-12d3-a456-426614174001',
+    idResource: '123e4567-e89b-12d3-a456-426614174002'
   } as Comment;
 
   const mockDeleteResult: DeleteResult = {
@@ -85,11 +85,11 @@ describe('CommentsService', () => {
 
   describe('findOne', () => {
     it('devrait retourner un commentaire par uuid', async () => {
-      const result = await service.findOne(mockComment.uuidComment);
+      const result = await service.findOne(mockComment.idComment);
 
       expect(result).toEqual(mockComment);
       expect(repository.findOne).toHaveBeenCalledWith({
-        where: { uuidComment: mockComment.uuidComment },
+        where: { idComment: mockComment.idComment },
         relations: ['member', 'resource']
       });
     });
@@ -103,11 +103,11 @@ describe('CommentsService', () => {
 
   describe('findByResource', () => {
     it('devrait retourner les commentaires d\'une ressource', async () => {
-      const result = await service.findByResource(mockComment.uuidResource);
+      const result = await service.findByResource(mockComment.idResource);
 
       expect(result).toEqual([mockComment]);
       expect(repository.find).toHaveBeenCalledWith({
-        where: { uuidResource: mockComment.uuidResource },
+        where: { idResource: mockComment.idResource },
         relations: ['member', 'resource'],
         order: {
           createdAt: 'DESC'
@@ -124,7 +124,7 @@ describe('CommentsService', () => {
       } as Comment;
       vi.spyOn(repository, 'save').mockResolvedValueOnce(updatedComment);
 
-      const result = await service.update(mockComment.uuidComment, mockUpdateDto);
+      const result = await service.update(mockComment.idComment, mockUpdateDto);
 
       expect(result).toEqual(updatedComment);
       expect(repository.save).toHaveBeenCalledWith(updatedComment);
@@ -139,9 +139,9 @@ describe('CommentsService', () => {
 
   describe('remove', () => {
     it('devrait supprimer un commentaire', async () => {
-      await service.remove(mockComment.uuidComment);
+      await service.remove(mockComment.idComment);
 
-      expect(repository.delete).toHaveBeenCalledWith({ uuidComment: mockComment.uuidComment });
+      expect(repository.delete).toHaveBeenCalledWith({ idComment: mockComment.idComment });
     });
 
     it('devrait lever une exception si le commentaire à supprimer n\'existe pas', async () => {

--- a/src/comments/comments.service.ts
+++ b/src/comments/comments.service.ts
@@ -26,22 +26,22 @@ export class CommentsService {
     });
   }
 
-  async findOne(uuid: string): Promise<Comment> {
+  async findOne(idComment: string): Promise<Comment> {
     const comment = await this.commentsRepository.findOne({
-      where: { uuidComment: uuid },
+      where: { idComment: idComment },
       relations: ['member', 'resource']
     });
     
     if (!comment) {
-      throw new NotFoundException(`Commentaire avec l'UUID ${uuid} non trouvé`);
+      throw new NotFoundException(`Commentaire avec l'id ${idComment} non trouvé`);
     }
     
     return comment;
   }
 
-  async findByResource(uuidResource: string): Promise<Comment[]> {
+  async findByResource(idResource: string): Promise<Comment[]> {
     const comments = await this.commentsRepository.find({
-      where: { uuidResource },
+      where: { idResource },
       relations: ['member', 'resource'],
       order: {
         createdAt: 'DESC'
@@ -51,19 +51,19 @@ export class CommentsService {
     return comments;
   }
 
-  async update(uuid: string, updateCommentDto: UpdateCommentDto): Promise<Comment> {
-    const comment = await this.findOne(uuid);
+  async update(idComment: string, updateCommentDto: UpdateCommentDto): Promise<Comment> {
+    const comment = await this.findOne(idComment);
     
     Object.assign(comment, updateCommentDto);
     
     return await this.commentsRepository.save(comment);
   }
 
-  async remove(uuid: string): Promise<void> {
-    const result = await this.commentsRepository.delete({ uuidComment: uuid });
+  async remove(idComment: string): Promise<void> {
+    const result = await this.commentsRepository.delete({ idComment: idComment });
     
     if (result.affected === 0) {
-      throw new NotFoundException(`Commentaire avec l'UUID ${uuid} non trouvé`);
+      throw new NotFoundException(`Commentaire avec l'id ${idComment} non trouvé`);
     }
   }
 }

--- a/src/comments/dto/create-comment.dto.ts
+++ b/src/comments/dto/create-comment.dto.ts
@@ -39,12 +39,12 @@ export class CreateCommentDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @IsUUID('4', { message: 'L\'UUID du membre doit être un UUID valide' })
-  uuidMember: string;
+  idMember: string;
 
   @ApiProperty({
     description: 'UUID de la ressource commentée',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @IsUUID('4', { message: 'L\'UUID de la ressource doit être un UUID valide' })
-  uuidResource: string;
+  idResource: string;
 }

--- a/src/comments/dto/update-comment.dto.ts
+++ b/src/comments/dto/update-comment.dto.ts
@@ -43,7 +43,7 @@ export class UpdateCommentDto extends PartialType(CreateCommentDto) {
    */
   @IsOptional()
   @IsUUID('4', { message: 'L\'ID de la ressource doit être un UUID valide' })
-  resource_uuid?: string;
+  idResource?: string;
 
   /**
    * Nouvel ID de l'utilisateur propriétaire
@@ -51,5 +51,5 @@ export class UpdateCommentDto extends PartialType(CreateCommentDto) {
    */
   @IsOptional()
   @IsUUID('4', { message: 'L\'ID de l\'utilisateur propriétaire doit être un UUID valide' })
-  user_uuid?: string;
+  idUser?: string;
 }

--- a/src/comments/entities/comment.entity.ts
+++ b/src/comments/entities/comment.entity.ts
@@ -7,11 +7,11 @@ import { Vote } from '../../votes/entities/vote.entity';
 @Entity('comments')
 export class Comment {
   @ApiProperty({
-    description: 'UUID unique du commentaire',
+    description: 'id unique du commentaire',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_comment' })
-  uuidComment: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_comment' })
+  idComment: string;
 
   @ApiProperty({
     description: 'Contenu du commentaire',
@@ -36,25 +36,25 @@ export class Comment {
   createdAt: Date;
 
   @ApiProperty({
-    description: 'UUID du membre qui a créé le commentaire',
+    description: 'id du membre qui a créé le commentaire',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ type: 'uuid', name: 'uuid_member' })
-  uuidMember: string;
+  @Column({ type: 'uuid', name: 'id_member' })
+  idMember: string;
 
   @ApiProperty({
-    description: 'UUID de la ressource commentée',
+    description: 'id de la ressource commentée',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ type: 'uuid', name: 'uuid_resource' })
-  uuidResource: string;
+  @Column({ type: 'uuid', name: 'id_resource' })
+  idResource: string;
 
   @ApiProperty({
     description: 'Le membre qui a créé le commentaire',
     type: () => Member
   })
   @ManyToOne(() => Member, member => member.comments)
-  @JoinColumn({ name: 'uuid_member' })
+  @JoinColumn({ name: 'id_member' })
   member: Member;
 
   @ApiProperty({
@@ -62,7 +62,7 @@ export class Comment {
     type: () => Resource
   })
   @ManyToOne(() => Resource, resource => resource.comments)
-  @JoinColumn({ name: 'uuid_resource' })
+  @JoinColumn({ name: 'id_resource' })
   resource: Resource;
 
   @ApiProperty({

--- a/src/courses/courses.controller.spec.ts
+++ b/src/courses/courses.controller.spec.ts
@@ -13,8 +13,8 @@ describe('CoursesController', () => {
     uuid: '123e4567-e89b-12d3-a456-426614174000',
     name: 'Développeur web',
     isCertified: true,
-    uuidCategory: '123456789012345678',
-    uuidGuild: '123456789012345678',
+    idCategory: '123456789012345678',
+    idGuild: '123456789012345678',
     createdAt: new Date(),
     updatedAt: null,
   };
@@ -22,9 +22,9 @@ describe('CoursesController', () => {
   const mockService = {
     create: vi.fn(),
     findAll: vi.fn(),
-    getByUUID: vi.fn(),
-    updateByUUID: vi.fn(),
-    deleteByUUID: vi.fn(),
+    getById: vi.fn(),
+    updateById: vi.fn(),
+    deleteById: vi.fn(),
   };
 
   beforeEach(async () => {
@@ -45,11 +45,12 @@ describe('CoursesController', () => {
   describe('create', () => {
     it('should create a course', async () => {
       const dto: CreateCourseDto = {
+        idCourse: '123456789012345678',
         name: 'Développeur web',
         isCertified: true,
-        uuidCategory: '123456789012345678',
-        uuidGuild: '123456789012345678',
-        uuidRole: ''
+        idCategory: '123456789012345678',
+        idGuild: '123456789012345678',
+        idRole: '123456789012345678'
       };
 
       mockService.create.mockResolvedValue({
@@ -80,42 +81,42 @@ describe('CoursesController', () => {
     });
   });
 
-  describe('getByUUID', () => {
+  describe('getById', () => {
     it('should return a course', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
-      mockService.getByUUID.mockResolvedValue(mockCourse);
+      mockService.getById.mockResolvedValue(mockCourse);
 
-      const result = await controller.getByUUID(uuid);
+      const result = await controller.getById(uuid);
 
       expect(result).toEqual(mockCourse);
-      expect(mockService.getByUUID).toHaveBeenCalledWith(uuid);
+      expect(mockService.getById).toHaveBeenCalledWith(uuid);
     });
   });
 
-  describe('updateByUUID', () => {
+  describe('updateById', () => {
     it('should update a course', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
       const updateDto: UpdateCourseDto = {
         name: 'updated-course'
       };
       const updatedCourse = { ...mockCourse, ...updateDto };
-      mockService.updateByUUID.mockResolvedValue(updatedCourse);
+      mockService.updateById.mockResolvedValue(updatedCourse);
 
-      const result = await controller.updateByUUID(uuid, updateDto);
+      const result = await controller.updateById(uuid, updateDto);
 
       expect(result).toEqual(updatedCourse);
-      expect(mockService.updateByUUID).toHaveBeenCalledWith(uuid, updateDto);
+      expect(mockService.updateById).toHaveBeenCalledWith(uuid, updateDto);
     });
   });
 
-  describe('deleteByUUID', () => {
+  describe('deleteById', () => {
     it('should delete a course', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
-      mockService.deleteByUUID.mockResolvedValue(undefined);
+      mockService.deleteById.mockResolvedValue(undefined);
 
-      await controller.deleteByUUID(uuid);
+      await controller.deleteById(uuid);
 
-      expect(mockService.deleteByUUID).toHaveBeenCalledWith(uuid);
+      expect(mockService.deleteById).toHaveBeenCalledWith(uuid);
     });
   });
 });

--- a/src/courses/courses.controller.ts
+++ b/src/courses/courses.controller.ts
@@ -63,14 +63,14 @@ export class CoursesController {
       return this.coursesService.findAll();
   }
 
-  @Get(':uuid_course')
+  @Get(':id')
   @ApiOperation({
-    summary: 'Récupérer une formation par son UUID',
+    summary: 'Récupérer une formation par son id',
     description: "Retourne les détails d'une formation spécifique",
   })
   @ApiParam({
-    name: 'uuid_course',
-    description: 'UUID de la formation',
+    name: 'id',
+    description: 'id de la formation',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
@@ -82,18 +82,18 @@ export class CoursesController {
     status: HttpStatus.NOT_FOUND,
     description: 'Formation non trouvée.',
   })
-  async getByUUID(@Param('uuid_course') uuid_course: string): Promise<Course> {
-    return this.coursesService.getByUUID(uuid_course);
+  async getById(@Param('id') idCourse: string): Promise<Course> {
+    return this.coursesService.getById(idCourse);
   }
 
-  @Put(':uuid_course')
+  @Put(':id')
   @ApiOperation({
     summary: 'Mettre à jour une formation',
     description: "Met à jour les informations d'une formation existante",
   })
   @ApiParam({
-    name: 'uuid_course',
-    description: 'UUID de la formation',
+    name: 'id',
+    description: 'id de la formation',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
@@ -113,21 +113,21 @@ export class CoursesController {
     status: HttpStatus.CONFLICT,
     description: 'Le nouveau nom est déjà utilisé par une autre formation.',
   })
-  async updateByUUID(
-    @Param('uuid_course') uuid_course: string,
+  async updateById(
+    @Param('id') idCourse: string,
     @Body() updateCourseDto: UpdateCourseDto,
   ): Promise<Course> {
-    return this.coursesService.updateByUUID(uuid_course, updateCourseDto);
+    return this.coursesService.updateById(idCourse, updateCourseDto);
   }
 
-  @Delete(':uuid_course')
+  @Delete(':id')
   @ApiOperation({
     summary: 'Supprimer une formation',
     description: 'Supprime une formation existante',
   })
   @ApiParam({
-    name: 'uuid_course',
-    description: 'UUID de la formation',
+    name: 'id',
+    description: 'id de la formation',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
@@ -142,7 +142,7 @@ export class CoursesController {
     status: HttpStatus.BAD_REQUEST,
     description: 'Erreur lors de la suppression de la formation.',
   })
-  async deleteByUUID(@Param('uuid_course') uuid_course: string): Promise<void> {
-    return this.coursesService.deleteByUUID(uuid_course);
+    async deleteById(@Param('id') idCourse: string): Promise<void> {
+    return this.coursesService.deleteById(idCourse);
   }
 }

--- a/src/courses/courses.service.spec.ts
+++ b/src/courses/courses.service.spec.ts
@@ -13,17 +13,17 @@ describe('CoursesService', () => {
   let repository: Repository<Course>;
 
   const mockCourse = {
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    idCourse: '123e4567-e89b-12d3-a456-426614174000',
     name: 'Développeur web',
     isCertified: true,
     createdAt: new Date(),
     updatedAt: null,
-    uuidCategory: '123456789012345678',
-    uuidGuild: '123456789012345678',
+    idCategory: '123456789012345678',
+    idGuild: '123456789012345678',
   };
 
   const mockRole = {
-    uuidRole: '123456789012345678',
+    idRole: '123456789012345678',
     name: 'Test Role',
     memberCount: 0,
     rolePosition: 1,
@@ -31,7 +31,7 @@ describe('CoursesService', () => {
     color: '#000000',
     createdAt: new Date(),
     updatedAt: null,
-    uuidGuild: '123456789012345678',
+    idGuild: '123456789012345678',
   };
 
   const mockRepository = {
@@ -77,16 +77,16 @@ describe('CoursesService', () => {
       const dto = {
           name: 'Développeur web',
           isCertified: true,
-          uuidCategory: '123456789012345678',
-          uuidGuild: '123456789012345678',
-          uuidRole: ''
+          idCategory: '123456789012345678',
+          idGuild: '123456789012345678',
+          idRole: ''
       };  
 
       mockRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(mockCourse);
       mockRepository.create.mockReturnValue(mockCourse);
       mockRepository.save.mockResolvedValue(mockCourse);
 
-      const result = await service.create(dto);
+      const result = await service.create(dto as CreateCourseDto);
       expect(result).toEqual(mockCourse);
   });
 
@@ -94,9 +94,9 @@ describe('CoursesService', () => {
       const dto = {
           name: 'Développeur web',
           isCertified: true,
-          uuidCategory: '123456789012345678',
-          uuidGuild: '123456789012345678',
-          uuidRole: '123456789012345678'
+          idCategory: '123456789012345678',
+          idGuild: '123456789012345678',
+          idRole: '123456789012345678'
       } as CreateCourseDto;  // Utiliser type assertion
 
       mockRepository.findOne.mockResolvedValueOnce(null).mockResolvedValueOnce(mockCourse);
@@ -110,12 +110,12 @@ describe('CoursesService', () => {
 
     it('should throw BadRequestException if course name exists', async () => {
       const dto = {
-        uuid: '123e4567-e89b-12d3-a456-426614174000',
+        idCourse: '123e4567-e89b-12d3-a456-426614174000',
         name: 'Développeur web',
-        uuidCategory: '123456789012345678',
-        uuidGuild: '123456789012345678',
+        idCategory: '123456789012345678',
+        idGuild: '123456789012345678',
         isCertified: true,
-        uuidRole: '123456789012345678'
+        idRole: '123456789012345678'
       };
 
       mockRepository.findOne.mockResolvedValue(mockCourse);
@@ -127,7 +127,7 @@ describe('CoursesService', () => {
 
   describe('findAll', () => {
     it('should return an array of courses', async () => {
-      const courses = [mockCourse, { ...mockCourse, uuid: '456' }];
+      const courses = [mockCourse, { ...mockCourse, idCourse: '456' }];
       mockRepository.find.mockResolvedValue(courses);
 
       const result = await service.findAll();
@@ -150,11 +150,11 @@ describe('CoursesService', () => {
     });
   });
 
-  describe('getByUUID', () => {
+  describe('getById', () => {
     it('should return a course', async () => {
       mockRepository.findOne.mockResolvedValue(mockCourse);
 
-      const result = await service.getByUUID(mockCourse.uuid);
+      const result = await service.getById(mockCourse.idCourse);
 
       expect(result).toEqual(mockCourse);
     });
@@ -162,11 +162,11 @@ describe('CoursesService', () => {
     it('should throw NotFoundException when course not found', async () => {
       mockRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.getByUUID('non-existent')).rejects.toThrow(NotFoundException);
+      await expect(service.getById('non-existent')).rejects.toThrow(NotFoundException);
     });
   });
 
-  describe('updateByUUID', () => {
+  describe('updateById', () => {
     it('should update a course', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
       const updateDto = {
@@ -181,11 +181,11 @@ describe('CoursesService', () => {
       });
       mockRepository.save.mockResolvedValue(updatedCourse);
 
-      const result = await service.updateByUUID(uuid, updateDto);
+      const result = await service.updateById(uuid, updateDto);
 
       expect(result).toEqual(updatedCourse);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuid },
+        where: { idCourse: uuid },
         relations: ['category', 'guild', 'roles', 'promotions', 'channels']
       });
       expect(mockRepository.save).toHaveBeenCalledWith({
@@ -204,13 +204,13 @@ describe('CoursesService', () => {
 
       mockRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.updateByUUID(uuid, updateDto))
+      await expect(service.updateById(uuid, updateDto))
         .rejects
         .toThrow(NotFoundException);
       
       expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuid },
+        where: { idCourse: uuid },
         relations: ['category', 'guild', 'roles', 'promotions', 'channels']
       });
 
@@ -234,11 +234,11 @@ describe('CoursesService', () => {
       })
       .mockResolvedValueOnce({ 
         ...mockCourse, 
-        uuid: 'different-uuid',
+        idCourse: 'different-uuid',
         name: 'existing-course' 
       }); 
 
-      await expect(service.updateByUUID(uuid, updateDto))
+      await expect(service.updateById(uuid, updateDto))
         .rejects
         .toThrow(ConflictException);
         
@@ -262,7 +262,7 @@ describe('CoursesService', () => {
       mockRepository.findOne.mockResolvedValue(courseWithRelations);
       mockRepository.save.mockResolvedValue({ ...courseWithRelations, ...updateDto });
   
-      const result = await service.updateByUUID(uuid, updateDto);
+      const result = await service.updateById(uuid, updateDto);
   
       expect(result.category).toBeDefined();
       expect(result.guild).toBeDefined();
@@ -272,43 +272,43 @@ describe('CoursesService', () => {
     });
   });
 
-  describe('deleteByUUID', () => {
+  describe('deleteById', () => {
     it('should delete a course', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
       
       mockRepository.findOne.mockResolvedValue(mockCourse);
       mockRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.deleteByUUID(uuid);
+      await service.deleteById(uuid);
 
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuid }
+        where: { idCourse: uuid }
       });
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuid: uuid });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idCourse: uuid });
     });
 
     it('should throw NotFoundException when deleting non-existent course', async () => {
-      const uuid = 'non-existent';
+      const idCourse = 'non-existent';
 
       mockRepository.findOne.mockReset();
       mockRepository.delete.mockReset();
 
       mockRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.deleteByUUID(uuid))
+      await expect(service.deleteById(idCourse))
         .rejects
         .toThrow(NotFoundException);
 
       expect(mockRepository.findOne).toHaveBeenCalledTimes(1);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuid }
+          where: { idCourse: idCourse }
       });
       
       expect(mockRepository.delete).not.toHaveBeenCalled();
     });
 
     it('should throw an error if delete operation fails', async () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const idCourse = '123e4567-e89b-12d3-a456-426614174000';
 
       mockRepository.findOne.mockReset();
       mockRepository.delete.mockReset();
@@ -316,15 +316,15 @@ describe('CoursesService', () => {
       mockRepository.findOne.mockResolvedValue(mockCourse);
       mockRepository.delete.mockResolvedValue({ affected: 0 });
 
-      await expect(service.deleteByUUID(uuid))
+      await expect(service.deleteById(idCourse))
         .rejects
         .toThrow('Failed to delete course');
 
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuid }
+        where: { idCourse: idCourse}
       });
 
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuid: uuid });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idCourse: idCourse });
     });
   });
 });

--- a/src/courses/courses.service.ts
+++ b/src/courses/courses.service.ts
@@ -30,16 +30,16 @@ export class CoursesService {
             const courseData = {
                 name: createCourseDto.name,
                 isCertified: createCourseDto.isCertified,
-                uuidGuild: createCourseDto.uuidGuild,
-                uuidCategory: createCourseDto.uuidCategory,
+                idGuild: createCourseDto.idGuild,
+                idCategory: createCourseDto.idCategory,
             };
 
             const newCourse = this.courseRepository.create(courseData);
             const savedCourse = await this.courseRepository.save(newCourse);
 
-            if (createCourseDto.uuidRole) {
+            if (createCourseDto.idRole) {
                 const role = await this.roleRepository.findOne({
-                    where: { uuidRole: createCourseDto.uuidRole }
+                    where: { idRole: createCourseDto.idRole }
                 });
 
                 if (role) {
@@ -47,12 +47,12 @@ export class CoursesService {
                         .createQueryBuilder()
                         .relation(Course, "roles")
                         .of(savedCourse)
-                        .add(role.uuidRole);
+                        .add(role.idRole);
                 }
             }
 
             const courseWithRelations = await this.courseRepository.findOne({
-                where: { uuid: savedCourse.uuid },
+                where: { idCourse: savedCourse.idCourse },
                 relations: {
                     category: true,
                     guild: true,
@@ -63,7 +63,7 @@ export class CoursesService {
             });
 
             if (!courseWithRelations) {
-                throw new NotFoundException(`Course with UUID ${savedCourse.uuid} not found after creation`);
+                throw new NotFoundException(`Course with id ${savedCourse.idCourse} not found after creation`);
             }
 
             return courseWithRelations;
@@ -78,33 +78,33 @@ export class CoursesService {
         });
     }
 
-    async getByUUID(uuid: string): Promise<Course> {
+    async getById(idCourse: string): Promise<Course> {
         const course = await this.courseRepository.findOne({
-            where: { uuid },
+            where: { idCourse },
             relations: ['category', 'guild', 'roles', 'promotions', 'channels'],
         });
 
         if (!course) {
-            throw new NotFoundException(`Course with UUID ${uuid} not found`);
+            throw new NotFoundException(`Course with id ${idCourse} not found`);
         }
         return course;
     }
 
-    async updateByUUID(uuid: string, updateCourseDto: UpdateCourseDto): Promise<Course> {
+    async updateById(idCourse: string, updateCourseDto: UpdateCourseDto): Promise<Course> {
         const course = await this.courseRepository.findOne({
-            where: { uuid },
+            where: { idCourse },
             relations: ['category', 'guild', 'roles', 'promotions', 'channels']
         });
 
         if (!course) {
-            throw new NotFoundException(`Course with UUID ${uuid} not found`);
+            throw new NotFoundException(`Course with id ${idCourse} not found`);
         }
 
         if (updateCourseDto.name) {
             const existingCourse = await this.courseRepository.findOne({
                 where: { name: updateCourseDto.name },
             });
-            if (existingCourse && existingCourse.uuid !== uuid) {
+            if (existingCourse && existingCourse.idCourse !== idCourse) {
                 throw new ConflictException(`Course with name ${updateCourseDto.name} already exists`);
             }
         }
@@ -113,15 +113,15 @@ export class CoursesService {
         return await this.courseRepository.save(course);
     }
 
-    async deleteByUUID(uuid: string): Promise<void> {
+    async deleteById(idCourse: string): Promise<void> {
         const course = await this.courseRepository.findOne({ 
-            where: { uuid } 
+            where: { idCourse } 
         });
 
         if (!course) {
-            throw new NotFoundException(`Course with UUID ${uuid} not found`);
+            throw new NotFoundException(`Course with id ${idCourse} not found`);
         }
-        const result = await this.courseRepository.delete({ uuid });
+        const result = await this.courseRepository.delete({ idCourse });
         if (result.affected === 0) {
             throw new BadRequestException('Failed to delete course');
         }

--- a/src/courses/dto/create-course.dto.spec.ts
+++ b/src/courses/dto/create-course.dto.spec.ts
@@ -5,38 +5,33 @@ import { CreateCourseDto } from "./create-course.dto";
 describe('CreateCourseDto', () => {
     it('should validate a valid DTO', async () => {
         const dto = new CreateCourseDto();
-        dto.name = 'Développeur web';
+        dto.name = 'Test Course';
         dto.isCertified = true;
-        dto.uuidGuild = '123456789012345678';
-        dto.uuidCategory = '123456789012345678';
-
+        dto.idRole = '123456789012345678';
+        
         const errors = await validate(dto);
-        expect(errors).toHaveLength(0);
+        expect(errors.length).toBe(0);
     });
 
     it('should fail validation for missing required fields', async () => {
         const dto = new CreateCourseDto();
-
         const errors = await validate(dto);
         
-        expect(errors).toHaveLength(4);
-        
-        const errorProperties = errors.map(error => error.property);
-        expect(errorProperties).toContain('name');
-        expect(errorProperties).toContain('isCertified');
-        expect(errorProperties).toContain('uuidGuild');
-        expect(errorProperties).toContain('uuidCategory');
+        const errorFields = errors.map(err => err.property);
+        expect(errorFields).toContain('name');
+        expect(errorFields).toContain('isCertified');
+        expect(errorFields).toContain('idRole');
     });
 
     it('should fail validation for short name', async () => {
         const dto = new CreateCourseDto();
-        dto.name = 'cd';
+        dto.name = 'ab';  // trop court
         dto.isCertified = true;
-        dto.uuidGuild = '123456789012345678';
-        dto.uuidCategory = '123456789012345678';
-
+        dto.idRole = '123456789012345678';
+        
         const errors = await validate(dto);
-        expect(errors).toHaveLength(1);
-        expect(errors[0].property).toBe('name');
+        const nameErrors = errors.find(err => err.property === 'name');
+        expect(errors.length).toBe(1);
+        expect(nameErrors?.constraints?.minLength).toBeDefined();
     });
 });

--- a/src/courses/dto/create-course.dto.ts
+++ b/src/courses/dto/create-course.dto.ts
@@ -1,14 +1,20 @@
 import { IsString, IsNotEmpty, IsBoolean, Length, Matches, IsOptional, MinLength } from "class-validator";
 import { ApiProperty, IntersectionType, PickType } from "@nestjs/swagger";
-import { PickableDiscordUUIDFields } from "src/utils/pickable-discord-uuid-fields";
+import { PickableDiscordIdFields} from "src/utils/pickable-discord-id-fields";
 import { PickableDtoFields } from "src/utils/pickable-dto-fields";
 
-export class CreateCourseDto extends PickType(IntersectionType(PickableDiscordUUIDFields, PickableDtoFields), [
+export class CreateCourseDto extends PickType(IntersectionType(PickableDiscordIdFields, PickableDtoFields), [
+    'idCourse',
     'name', 
-    'uuidGuild', 
-    'uuidRole',
-    'uuidCategory'
+    'idGuild', 
+    'idCategory'
 ]) {
+    @ApiProperty({
+        description: 'Nom de la formation',
+        type: String,
+        example: 'Développeur web',
+    })
+    @IsNotEmpty()
     @MinLength(3)
     name: string;
 
@@ -22,5 +28,5 @@ export class CreateCourseDto extends PickType(IntersectionType(PickableDiscordUU
     isCertified: boolean;
 
     @IsOptional()
-    uuidRole: string;
+    idRole: string;
 }

--- a/src/courses/entities/course.entity.ts
+++ b/src/courses/entities/course.entity.ts
@@ -1,8 +1,7 @@
 import {
   Entity,
-  PrimaryGeneratedColumn,
+  PrimaryColumn,
   Column,
-  OneToOne,
   JoinColumn,
   OneToMany,
   ManyToOne,
@@ -20,11 +19,11 @@ import { ApiProperty } from '@nestjs/swagger';
 export class Course {
 
   @ApiProperty({
-    description: 'UUID unique de la formation',
-    example: '123e4567-e89b-12d3-a456-426614174000',
+    description: 'SF discord de la formation',
+    example: '123456789012345678',
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_course' })
-    uuid: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_course' })
+    idCourse: string;
 
   @ApiProperty({
     description: 'Nom de la formation',
@@ -68,37 +67,34 @@ export class Course {
     type: () => Guild,
   })
   @ManyToOne(() => Guild, (guild) => guild.courses)
-  @JoinColumn({ name: 'uuid_guild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 
   @ApiProperty({
-    description: 'UUID unique de la guilde',
+    description: 'SF unique de la guilde',
     example: '123456789012345678',
   })
-  @Column({ name: 'uuid_guild', type: 'varchar', length: 19})
-    uuidGuild: string;
+  @Column({ name: 'id_guild', type: 'varchar', length: 19})
+    idGuild: string;
   
   @ApiProperty({
     description: 'Catégorie associée à la formation',
-    example: {
-      uuid: '123456789012345678',
-      name: 'Développement Web',
-    },
+    type: () => Category
   })
-  @ManyToOne(() => Category, (category) => category.course)
-  @JoinColumn({ name: 'uuid_category' })
+  @ManyToOne(() => Category, category => category.courses)
+  @JoinColumn({ name: 'id_category' })
   category: Category;
 
   @ApiProperty({
-    description: 'UUID unique de la catégorie',
+    description: 'id unique de la catégorie',
     example: '123456789012345678'
   })
   @Column({
-    name: 'uuid_category',
+    name: 'id_category',
     type: 'varchar',
     length: 19
   })
-  uuidCategory: string;
+  idCategory: string;
   
   @ApiProperty({
     description: 'Rôles associés aux formations',
@@ -111,12 +107,12 @@ export class Course {
   @JoinTable({
     name: 'courses_roles',
     joinColumns: [{
-        name: 'uuid_course',
-        referencedColumnName: 'uuid'
+        name: 'id_course',
+        referencedColumnName: 'idCourse'
     }],
     inverseJoinColumns: [{
-        name: 'uuid_role',
-        referencedColumnName: 'uuidRole'
+        name: 'id_role',
+        referencedColumnName: 'idRole'
     }]
   })
   roles: Role[];

--- a/src/dashboard-accounts/dashboard-accounts.controller.spec.ts
+++ b/src/dashboard-accounts/dashboard-accounts.controller.spec.ts
@@ -4,7 +4,6 @@ import { DashboardAccountService } from './dashboard-accounts.service';
 import { CreateDashboardAccountDto } from './dto/create-dashboard-account.dto';
 import { UpdateDashboardAccountDto } from './dto/update-dashboard-account.dto';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
-import { ValidationPipe } from '@nestjs/common';
 import { validate } from 'class-validator';
 
 describe('DashboardAccountController', () => {
@@ -18,9 +17,9 @@ describe('DashboardAccountController', () => {
 
   const mockService = {
     create: vi.fn(),
-    getByUUID: vi.fn(),
-    updateByUUID: vi.fn(),
-    deleteByUUID: vi.fn(),
+    getById: vi.fn(),
+    updateById: vi.fn(),
+    deleteById: vi.fn(),
   };
 
   beforeEach(async () => {
@@ -45,7 +44,8 @@ describe('DashboardAccountController', () => {
   describe('create', () => {
     it('should create a dashboard account', async () => {
       const dto: CreateDashboardAccountDto = {
-        uuid_discord: '123456789012345678',
+        idDashboardAccount: '123456789012345678',
+        idDiscord: '123456789012345678',
         email: 'test@example.com',
         password: 'password123' 
       };
@@ -58,33 +58,92 @@ describe('DashboardAccountController', () => {
       expect(mockService.create).toHaveBeenCalledWith(dto);
     });
 
-    // Ajout d'un test pour la validation
-    it('should validate the DTO', async () => {
+    describe('validation', () => {
+      it('should reject invalid email', async () => {
         const invalidDto = new CreateDashboardAccountDto();
+        invalidDto.idDashboardAccount = '123456789012345678';
+        invalidDto.idDiscord = '123456789012345678';
         invalidDto.email = 'invalid-email';
+        invalidDto.password = 'ValidPassword123!';
+
+        const errors = await validate(invalidDto);
+        expect(errors.length).toBeGreaterThan(0);
+        const emailError = errors.find(err => err.property === 'email');
+        expect(emailError).toBeDefined();
+        expect(emailError?.constraints?.isEmail).toBeDefined();
+      });
+
+      it('should reject password that is too short', async () => {
+        const invalidDto = new CreateDashboardAccountDto();
+        invalidDto.idDashboardAccount = '123456789012345678';
+        invalidDto.idDiscord = '123456789012345678';
+        invalidDto.email = 'valid@example.com';
         invalidDto.password = 'short';
 
         const errors = await validate(invalidDto);
-      
-        expect(errors.length).toBeGreaterThan(0);
-        expect(errors.some(err => err.property === 'email')).toBeTruthy();
-        expect(errors.some(err => err.property === 'password')).toBeTruthy();
+        
+        const passwordErrors = errors.find(err => err.property === 'password');
+        expect(passwordErrors).toBeDefined();
+        expect(passwordErrors?.constraints).toHaveProperty('minLength');
       });
-});
 
-  describe('getByUUID', () => {
-    it('should return a single dashboard account', async () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
-      mockService.getByUUID.mockResolvedValue(mockDashboardAccount);
+      it('should reject invalid Discord IDs', async () => {
+        const invalidDto = new CreateDashboardAccountDto();
+        invalidDto.idDashboardAccount = 'invalid-id';
+        invalidDto.idDiscord = 'invalid-id';
+        invalidDto.email = 'valid@example.com';
+        invalidDto.password = 'ValidPassword123!';
 
-      const result = await controller.getByUUID(uuid);
+        const errors = await validate(invalidDto);
+        expect(errors.length).toBeGreaterThan(0);
+        
+        const idDiscordError = errors.find(err => err.property === 'idDiscord');
+        expect(idDiscordError).toBeDefined();
+        expect(idDiscordError?.constraints?.matches).toBeDefined();
 
-      expect(result).toEqual(mockDashboardAccount);
-      expect(mockService.getByUUID).toHaveBeenCalledWith(uuid);
+        const idDashboardError = errors.find(err => err.property === 'idDashboardAccount');
+        expect(idDashboardError).toBeDefined();
+        expect(idDashboardError?.constraints?.matches).toBeDefined();
+      });
+
+      it('should accept a valid DTO', async () => {
+        const validDto = new CreateDashboardAccountDto();
+        validDto.idDashboardAccount = '123456789012345678';
+        validDto.idDiscord = '123456789012345678';
+        validDto.email = 'valid@example.com';
+        validDto.password = 'ValidPassword123!';
+
+        const errors = await validate(validDto);
+        expect(errors).toHaveLength(0);
+      });
+
+      it('should reject missing required fields', async () => {
+        const emptyDto = new CreateDashboardAccountDto();
+        
+        const errors = await validate(emptyDto);
+        expect(errors).toHaveLength(4);
+        
+        errors.forEach(error => {
+          expect(error.constraints).toBeDefined();
+          expect(error.constraints?.isNotEmpty).toBeDefined();
+        });
+      });
     });
   });
 
-  describe('updateByUUID', () => {
+  describe('getById', () => {
+    it('should return a single dashboard account', async () => {
+      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      mockService.getById.mockResolvedValue(mockDashboardAccount);
+
+      const result = await controller.getById(uuid);
+
+      expect(result).toEqual(mockDashboardAccount);
+      expect(mockService.getById).toHaveBeenCalledWith(uuid);
+    });
+  });
+
+  describe('updateById', () => {
     it('should update a dashboard account', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
       const updateDto: UpdateDashboardAccountDto = {
@@ -92,23 +151,23 @@ describe('DashboardAccountController', () => {
           password: ''
       };
       const updatedAccount = { ...mockDashboardAccount, ...updateDto };
-      mockService.updateByUUID.mockResolvedValue(updatedAccount);
+      mockService.updateById.mockResolvedValue(updatedAccount);
 
-      const result = await controller.updateByUUID(uuid, updateDto);
+      const result = await controller.updateById(uuid, updateDto);
 
       expect(result).toEqual(updatedAccount);
-      expect(mockService.updateByUUID).toHaveBeenCalledWith(uuid, updateDto);
+      expect(mockService.updateById).toHaveBeenCalledWith(uuid, updateDto);
     });
   });
 
-  describe('deleteByUUID', () => {
+  describe('deleteById', () => {
     it('should delete a dashboard account', async () => {
       const uuid = '123e4567-e89b-12d3-a456-426614174000';
-      mockService.deleteByUUID.mockResolvedValue(undefined);
+      mockService.deleteById.mockResolvedValue(undefined);
 
-      await controller.deleteByUUID(uuid);
+      await controller.deleteById(uuid);
 
-      expect(mockService.deleteByUUID).toHaveBeenCalledWith(uuid);
+      expect(mockService.deleteById).toHaveBeenCalledWith(uuid);
     });
   });
 });

--- a/src/dashboard-accounts/dashboard-accounts.controller.ts
+++ b/src/dashboard-accounts/dashboard-accounts.controller.ts
@@ -28,8 +28,8 @@ export class DashboardAccountController {
         return this.dashboardAccountService.create(createDashboardAccountDto);
     }
   
-    @Get(':uuidDashboardAccount')
-    @ApiOperation({ summary: 'Récupérer un compte dashboard par son UUID' })
+    @Get(':id')
+    @ApiOperation({ summary: 'Récupérer un compte dashboard par son id' })
     @ApiResponse({ 
         status: HttpStatus.OK, 
         description: 'Le compte a été trouvé',
@@ -39,11 +39,11 @@ export class DashboardAccountController {
         status: HttpStatus.NOT_FOUND, 
         description: 'Compte non trouvé'
     })
-    async getByUUID(@Param('uuidDashboardAccount') uuidDashboardAccount: string): Promise<DashboardAccount> {
-        return this.dashboardAccountService.getByUUID(uuidDashboardAccount);
+    async getById(@Param('id') idDashboardAccount: string): Promise<DashboardAccount> {
+        return this.dashboardAccountService.getById(idDashboardAccount);
     }
 
-    @Put(':uuidDashboardAccount')
+    @Put(':id')
     @ApiOperation({ summary: 'Mettre à jour un compte dashboard' })
     @ApiResponse({ 
         status: HttpStatus.OK, 
@@ -58,14 +58,14 @@ export class DashboardAccountController {
         status: HttpStatus.BAD_REQUEST, 
         description: 'Données invalides fournies'
     })
-    async updateByUUID(
-        @Param('uuidDashboardAccount') uuidDashboardAccount: string,
+    async updateById(
+        @Param('id') idDashboardAccount: string,
         @Body() updateDashboardAccountDto: UpdateDashboardAccountDto,
     ): Promise<DashboardAccount> {
-        return this.dashboardAccountService.updateByUUID(uuidDashboardAccount, updateDashboardAccountDto);
+        return this.dashboardAccountService.updateById(idDashboardAccount, updateDashboardAccountDto);
     }
 
-    @Delete(':uuidDashboardAccount')
+    @Delete(':id')
     @ApiOperation({ summary: 'Supprimer un compte dashboard' })
     @ApiResponse({ 
         status: HttpStatus.NO_CONTENT, 
@@ -75,7 +75,7 @@ export class DashboardAccountController {
         status: HttpStatus.NOT_FOUND, 
         description: 'Compte non trouvé'
     })
-    async deleteByUUID(@Param('uuidDashboardAccount') uuidDashboardAccount: string): Promise<void> {
-        return this.dashboardAccountService.deleteByUUID(uuidDashboardAccount);
+        async deleteById(@Param('id') idDashboardAccount: string): Promise<void> {
+        return this.dashboardAccountService.deleteById(idDashboardAccount);
     }
 }

--- a/src/dashboard-accounts/dashboard-accounts.service.spec.ts
+++ b/src/dashboard-accounts/dashboard-accounts.service.spec.ts
@@ -11,8 +11,8 @@ describe('DashboardAccountService', () => {
   let repository: Repository<DashboardAccount>;
 
   const mockDashboardAccount = {
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
-    uuidDiscord: '123456789012345678',
+    idDashboardAccount: '123e4567-e89b-12d3-a456-426614174000',
+    idDiscord: '123456789012345678',
     email: 'test@example.com',
     password: 'hashedPassword123'
   };
@@ -49,60 +49,60 @@ describe('DashboardAccountService', () => {
       mockRepository.create.mockReturnValue(mockDashboardAccount);
       mockRepository.save.mockResolvedValue(mockDashboardAccount);
 
-      const createDtoWithUUID = {
+      const createDtoWithId = {
         ...createDto,
-        uuid: mockDashboardAccount.uuid,
-        uuidDiscord: mockDashboardAccount.uuidDiscord
+        idDashboardAccount: mockDashboardAccount.idDashboardAccount,
+        idDiscord: mockDashboardAccount.idDiscord
       };
 
-      const result = await service.create(createDtoWithUUID);
+      const result = await service.create(createDtoWithId);
 
       expect(result).toEqual(mockDashboardAccount);
-      expect(mockRepository.create).toHaveBeenCalledWith(createDtoWithUUID);
+      expect(mockRepository.create).toHaveBeenCalledWith(createDtoWithId);
       expect(mockRepository.save).toHaveBeenCalledWith(mockDashboardAccount);
     });
   });
 
-  describe('getByUUID', () => {
+  describe('getById', () => {
     it('should return a dashboard account', async () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const idDashboardAccount = '123e4567-e89b-12d3-a456-426614174000';
       mockRepository.findOne.mockResolvedValue(mockDashboardAccount);
 
-      const result = await service.getByUUID(uuid);
+      const result = await service.getById(idDashboardAccount);
 
       expect(result).toEqual(mockDashboardAccount);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid }
+        where: { idDashboardAccount }
       });
     });
 
     it('should throw NotFoundException when account not found', async () => {
-      const uuid = 'non-existent-uuid';
+      const idDashboardAccount = 'non-existent-uuid';
       mockRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.getByUUID(uuid)).rejects.toThrow(NotFoundException);
+      await expect(service.getById(idDashboardAccount)).rejects.toThrow(NotFoundException);
     });
   });
 
-  describe('deleteByUUID', () => {
+  describe('deleteById', () => {
     it('should delete a dashboard account', async () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const idDashboardAccount = '123e4567-e89b-12d3-a456-426614174000';
       mockRepository.findOne.mockResolvedValue(mockDashboardAccount);
       mockRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.deleteByUUID(uuid);
+      await service.deleteById(idDashboardAccount);
 
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid }
+        where: { idDashboardAccount }
       });
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuid });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idDashboardAccount });
     });
 
     it('should throw NotFoundException when account not found', async () => {
-      const uuid = 'non-existent-uuid';
+      const idDashboardAccount = 'non-existent-uuid';
       mockRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.deleteByUUID(uuid)).rejects.toThrow(NotFoundException);
+      await expect(service.deleteById(idDashboardAccount)).rejects.toThrow(NotFoundException);
     });
   });
 });

--- a/src/dashboard-accounts/dashboard-accounts.service.ts
+++ b/src/dashboard-accounts/dashboard-accounts.service.ts
@@ -18,29 +18,29 @@ export class DashboardAccountService {
         return await this.dashboardAccountRepository.save(dashboardAccount);
     }
 
-    async getByUUID(uuid: string): Promise<DashboardAccount> {
-        const dashboardAccount = await this.dashboardAccountRepository.findOne({ where: { uuid } });
+    async getById(idDashboardAccount: string): Promise<DashboardAccount> {
+        const dashboardAccount = await this.dashboardAccountRepository.findOne({ where: { idDashboardAccount } });
         if (!dashboardAccount) {
-            throw new NotFoundException(`Dashboard account with UUID ${uuid} not found`);
+            throw new NotFoundException(`Dashboard account with id ${idDashboardAccount} not found`);
         }
         return dashboardAccount;
     }
 
-    async updateByUUID(uuid: string, updateDashboardAccountDto: UpdateDashboardAccountDto): Promise<DashboardAccount> {
-        const dashboardAccount = await this.getByUUID(uuid); // Vérifie si l'entité existe
+    async updateById(idDashboardAccount: string, updateDashboardAccountDto: UpdateDashboardAccountDto): Promise<DashboardAccount> {
+        const dashboardAccount = await this.getById(idDashboardAccount); // Vérifie si l'entité existe
         Object.assign(dashboardAccount, updateDashboardAccountDto); // Met à jour les propriétés
         return await this.dashboardAccountRepository.save(dashboardAccount);
     }
 
-    async deleteByUUID(uuid: string): Promise<void> {
+    async deleteById(idDashboardAccount: string): Promise<void> {
         const dashboardAccount = await this.dashboardAccountRepository.findOne({ 
-            where: { uuid } 
+            where: { idDashboardAccount } 
         });
         
         if (!dashboardAccount) {
-            throw new NotFoundException(`Dashboard account with UUID ${uuid} not found`);
+            throw new NotFoundException(`Dashboard account with id ${idDashboardAccount} not found`);
         }
         
-        await this.dashboardAccountRepository.delete({ uuid });
+        await this.dashboardAccountRepository.delete({ idDashboardAccount });
     }
 }

--- a/src/dashboard-accounts/dto/create-dashboard-account.dto.spec.ts
+++ b/src/dashboard-accounts/dto/create-dashboard-account.dto.spec.ts
@@ -5,12 +5,12 @@ import { CreateDashboardAccountDto } from './create-dashboard-account.dto';
 describe('CreateDashboardAccountDto', () => {
     it('should validate a valid DTO', async () => {
         const dto = new CreateDashboardAccountDto();
-        dto.uuidDiscord = '123456789012345678';
+        dto.idDashboardAccount = '123456789012345678';
+        dto.idDiscord = '123456789012345678';
         dto.email = 'test@example.com';
-        dto.password = 'password123';
-
+        dto.password = 'ValidPassword123!';
         const errors = await validate(dto);
-        expect(errors).toHaveLength(0);
+        expect(errors.length).toBe(0);
     });
 
     it('should fail validation for missing required fields', async () => {
@@ -18,33 +18,32 @@ describe('CreateDashboardAccountDto', () => {
 
         const errors = await validate(dto);
         
-        expect(errors).toHaveLength(3);
-        
-        const errorProperties = errors.map(error => error.property);
-        expect(errorProperties).toContain('email');
-        expect(errorProperties).toContain('password');
-        expect(errorProperties).toContain('uuidDiscord');
+        expect(errors.length).toBe(4);
     });
 
     it('should fail validation for invalid email', async () => {
         const dto = new CreateDashboardAccountDto();
-        dto.uuidDiscord = '123456789012345678';
+        dto.idDashboardAccount = '123456789012345678';
+        dto.idDiscord = '123456789012345678';
         dto.email = 'invalid-email';
-        dto.password = 'password123';
+        dto.password = 'ValidPassword123!';
 
         const errors = await validate(dto);
-        expect(errors).toHaveLength(1);
-        expect(errors[0].property).toBe('email');
+        const emailError = errors.find(err => err.property === 'email');
+        expect(emailError).toBeDefined();
+        expect(emailError?.constraints?.isEmail).toBeDefined();
     });
 
     it('should fail validation for short password', async () => {
         const dto = new CreateDashboardAccountDto();
-        dto.uuidDiscord = '123456789012345678';
+        dto.idDashboardAccount = '123456789012345678';
+        dto.idDiscord = '123456789012345678';
         dto.email = 'test@example.com';
         dto.password = 'short';
 
         const errors = await validate(dto);
-        expect(errors).toHaveLength(1);
-        expect(errors[0].property).toBe('password');
+        const passwordError = errors.find(err => err.property === 'password');
+        expect(errors.length).toBe(1);
+        expect(passwordError?.constraints?.minLength).toBeDefined();
     });
 });

--- a/src/dashboard-accounts/dto/create-dashboard-account.dto.ts
+++ b/src/dashboard-accounts/dto/create-dashboard-account.dto.ts
@@ -1,20 +1,14 @@
 import { IsString, IsEmail, MinLength, IsNotEmpty } from 'class-validator';
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
+import { ApiProperty, PickType, IntersectionType } from '@nestjs/swagger';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
+import { PickableDtoFields } from 'src/utils/pickable-dto-fields';
 
-export class CreateDashboardAccountDto extends PickType(PickableDiscordUUIDFields, [
-    'uuidDiscord'
+export class CreateDashboardAccountDto extends PickType(IntersectionType(PickableDiscordIdFields, PickableInternIdFields, PickableDtoFields), [
+    'idDashboardAccount',
+    'idDiscord',
+    'email'
 ]) {
-
-    @ApiProperty({
-        description: 'Email associé au compte du dashboard',
-        type: String,
-        example: 'test@example.com',
-    })
-    @IsNotEmpty()
-    @IsEmail()
-    email: string;
-
     @ApiProperty({
         description: 'Mot de passe associé au compte du dashboard',
         type: String,
@@ -24,6 +18,4 @@ export class CreateDashboardAccountDto extends PickType(PickableDiscordUUIDField
     @IsString()
     @MinLength(8)
     password: string;
-
-    uuidDiscord: string;
 }

--- a/src/dashboard-accounts/entities/dashboard-account.entity.ts
+++ b/src/dashboard-accounts/entities/dashboard-account.entity.ts
@@ -3,8 +3,8 @@ import { DiscordUser } from '../../discord-users/entities/discord-user.entity';
 
 @Entity('dashboard_accounts')
 export class DashboardAccount {
-    @PrimaryGeneratedColumn('uuid', { name: 'uuid_dashboard_account' })
-    uuid: string;
+    @PrimaryGeneratedColumn('uuid', { name: 'id_dashboard_account' })
+    idDashboardAccount: string;
 
     @Column({ type: 'varchar', unique: true })
     email: string;
@@ -26,10 +26,10 @@ export class DashboardAccount {
       })
     updatedAt: Date;
 
-    @Column({ type: 'uuid', name: 'uuid_discord' })
-    uuidDiscord: string;
+    @Column({ type: 'uuid', name: 'id_discord' })
+    idDiscord: string;
 
     @OneToOne(() => DiscordUser, discordUser => discordUser.dashboardAccount)
-    @JoinColumn({ name: 'uuidDiscord' })
+    @JoinColumn({ name: 'id_discord' })
     discordUser: DiscordUser;
 }

--- a/src/discord-users/discord-users.controller.spec.ts
+++ b/src/discord-users/discord-users.controller.spec.ts
@@ -26,7 +26,7 @@ describe('DiscordUsersController', () => {
 
   it('should create a new discord user', async () => {
     const dto: CreateDiscordUserDto = {
-      uuidDiscord: '123456789012345678',
+      idDiscord: '123456789012345678',
       discordUsername: 'JohnDoe#1234',
       discriminator: '1234',
     };
@@ -36,14 +36,14 @@ describe('DiscordUsersController', () => {
   });
 
   it('should return an array of discord users', async () => {
-    const result = [{ uuidDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' }];
+    const result = [{ idDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' }];
     mockDiscordUsersService.findAll.mockResolvedValue(result);
     expect(await controller.findAll()).toEqual(result);
     expect(mockDiscordUsersService.findAll).toHaveBeenCalled();
   });
 
   it('should return a single discord user', async () => {
-    const result = { uuidDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' };
+    const result = { idDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' };
     mockDiscordUsersService.findOne.mockResolvedValue(result);
     expect(await controller.findOne('123456789012345678')).toEqual(result);
     expect(mockDiscordUsersService.findOne).toHaveBeenCalledWith('123456789012345678');
@@ -55,7 +55,7 @@ describe('DiscordUsersController', () => {
       discriminator: '4321',
     };
     const result = {
-      uuidDiscord: '123456789012345678',
+      idDiscord: '123456789012345678',
       ...dto,
     };
     mockDiscordUsersService.update.mockResolvedValue(result);

--- a/src/discord-users/discord-users.controller.ts
+++ b/src/discord-users/discord-users.controller.ts
@@ -25,31 +25,31 @@ export class DiscordUsersController {
     return this.discordUsersService.findAll();
   }
 
-  @Get(':uuidDiscord')
-  @ApiOperation({ summary: 'Récupérer un utilisateur Discord par son UUID' })
+  @Get(':idDiscord')
+  @ApiOperation({ summary: 'Récupérer un utilisateur Discord par son id' })
   @ApiResponse({ status: 200, description: 'L\'utilisateur a été trouvé.', type: DiscordUser })
   @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
-  findOne(@Param('uuidDiscord') uuidDiscord: string) {
-    return this.discordUsersService.findOne(uuidDiscord);
+  findOne(@Param('idDiscord') idDiscord: string) {
+    return this.discordUsersService.findOne(idDiscord);
   }
 
-  @Put(':uuidDiscord')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour un utilisateur Discord' })
   @ApiResponse({ status: 200, description: 'L\'utilisateur a été mis à jour avec succès.', type: DiscordUser })
   @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
-  async update(@Param('uuidDiscord') uuidDiscord: string, @Body() updateDiscordUserDto: UpdateDiscordUserDto) {
-    const discordUser = await this.discordUsersService.update(uuidDiscord, updateDiscordUserDto);
+  async update(@Param('id') idDiscord: string, @Body() updateDiscordUserDto: UpdateDiscordUserDto) {
+    const discordUser = await this.discordUsersService.update(idDiscord, updateDiscordUserDto);
     if (!discordUser) {
-      throw new NotFoundException(`Discord user with UUID "${uuidDiscord}" not found`);
+      throw new NotFoundException(`Discord user with id "${idDiscord}" not found`);
     }
     return discordUser;
   }
 
-  @Delete(':uuidDiscord')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer un utilisateur Discord' })
   @ApiResponse({ status: 200, description: 'L\'utilisateur a été supprimé avec succès.' })
   @ApiResponse({ status: 404, description: 'Utilisateur non trouvé' })
-  remove(@Param('uuidDiscord') uuidDiscord: string) {
-    return this.discordUsersService.remove(uuidDiscord);
+  remove(@Param('id') idDiscord: string) {
+    return this.discordUsersService.remove(idDiscord);
   }
 } 

--- a/src/discord-users/discord-users.service.spec.ts
+++ b/src/discord-users/discord-users.service.spec.ts
@@ -26,7 +26,7 @@ describe('DiscordUsersService', () => {
 
   it('should create a new discord user', async () => {
     const dto: CreateDiscordUserDto = {
-      uuidDiscord: '123456789012345678',
+      idDiscord: '123456789012345678',
       discordUsername: 'JohnDoe#1234',
       discriminator: '1234',
     };
@@ -40,17 +40,17 @@ describe('DiscordUsersService', () => {
   });
 
   it('should return an array of discord users', async () => {
-    const result = [{ uuidDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' }];
+    const result = [{ idDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' }];
     mockRepository.find.mockResolvedValue(result);
     expect(await service.findAll()).toEqual(result);
     expect(mockRepository.find).toHaveBeenCalled();
   });
 
   it('should return a single discord user', async () => {
-    const result = { uuidDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' };
+    const result = { idDiscord: '123456789012345678', discordUsername: 'JohnDoe#1234', discriminator: '1234' };
     mockRepository.findOneBy.mockResolvedValue(result);
     expect(await service.findOne('123456789012345678')).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuidDiscord: '123456789012345678' });
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idDiscord: '123456789012345678' });
   });
 
   it('should update a discord user', async () => {
@@ -59,7 +59,7 @@ describe('DiscordUsersService', () => {
       discriminator: '4321',
     };
     const existingUser = {
-      uuidDiscord: '123456789012345678',
+      idDiscord: '123456789012345678',
       discordUsername: 'JohnDoe#1234',
       discriminator: '1234',
       updatedAt: new Date(),
@@ -69,13 +69,13 @@ describe('DiscordUsersService', () => {
     mockRepository.save.mockResolvedValue(updatedUser);
 
     expect(await service.update('123456789012345678', dto)).toEqual(updatedUser);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuidDiscord: '123456789012345678' });
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idDiscord: '123456789012345678' });
     expect(mockRepository.save).toHaveBeenCalled();
   });
 
   it('should delete a discord user', async () => {
     mockRepository.delete.mockResolvedValue({ affected: 1 });
     expect(await service.remove('123456789012345678')).toEqual({ affected: 1 });
-    expect(mockRepository.delete).toHaveBeenCalledWith({ uuidDiscord: '123456789012345678' });
+    expect(mockRepository.delete).toHaveBeenCalledWith({ idDiscord: '123456789012345678' });
   });
 }); 

--- a/src/discord-users/discord-users.service.ts
+++ b/src/discord-users/discord-users.service.ts
@@ -21,12 +21,12 @@ export class DiscordUsersService {
     return this.discordUserRepository.find();
   }
 
-  findOne(uuidDiscord: string) {
-    return this.discordUserRepository.findOneBy({ uuidDiscord });
+  findOne(idDiscord: string) {
+    return this.discordUserRepository.findOneBy({ idDiscord });
   }
 
-  async update(uuidDiscord: string, updateDiscordUserDto: UpdateDiscordUserDto) {
-    const discordUser = await this.discordUserRepository.findOneBy({ uuidDiscord });
+  async update(idDiscord: string, updateDiscordUserDto: UpdateDiscordUserDto) {
+    const discordUser = await this.discordUserRepository.findOneBy({ idDiscord });
     if (!discordUser) {
       return null;
     }
@@ -39,7 +39,7 @@ export class DiscordUsersService {
     return this.discordUserRepository.save(discordUser);
   }
 
-  remove(uuidDiscord: string) {
-    return this.discordUserRepository.delete({ uuidDiscord });
+  remove(idDiscord: string) {
+    return this.discordUserRepository.delete({ idDiscord });
   }
 } 

--- a/src/discord-users/dto/create-discord-user.dto.ts
+++ b/src/discord-users/dto/create-discord-user.dto.ts
@@ -1,9 +1,9 @@
 import { IsString, Length } from 'class-validator';
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
 
-export class CreateDiscordUserDto extends PickType(PickableDiscordUUIDFields, [
-  'uuidDiscord'
+export class CreateDiscordUserDto extends PickType(PickableDiscordIdFields, [
+  'idDiscord'
 ]) {
   @ApiProperty({
     description: 'Nom d\'utilisateur Discord',

--- a/src/discord-users/dto/update-discord-user.dto.ts
+++ b/src/discord-users/dto/update-discord-user.dto.ts
@@ -2,5 +2,5 @@ import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateDiscordUserDto } from './create-discord-user.dto';
 
 export class UpdateDiscordUserDto extends PartialType(
-  OmitType(CreateDiscordUserDto, ['uuidDiscord'] as const),
+  OmitType(CreateDiscordUserDto, ['idDiscord'] as const),
 ) {} 

--- a/src/discord-users/entities/discord-user.entity.ts
+++ b/src/discord-users/entities/discord-user.entity.ts
@@ -8,24 +8,24 @@ import { DashboardAccount } from 'src/dashboard-accounts/entities/dashboard-acco
 export class DiscordUser {
 
   @ApiProperty({
-    description: 'ID Discord de l\'utilisateur',
+    description: 'SF Discord de l\'utilisateur',
     example: '123456789012345678'
   })
-  @PrimaryColumn({ type: 'varchar', length: 19, name: 'uuid_discord' })
-  uuidDiscord: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_discord' })
+  idDiscord: string;
 
   @ApiProperty({
     description: 'Nom d\'utilisateur Discord',
     example: 'JohnDoe#1234'
   })
-  @Column({ type: 'varchar', length: 50, name: 'discord_username' })
+  @Column({ type: 'varchar', length: 32, name: 'discord_username' })
   discordUsername: string;
 
   @ApiProperty({
     description: 'Discriminateur Discord',
     example: '1234'
   })
-  @Column({ type: 'varchar', length: 50, name: 'discriminator' })
+  @Column({ type: 'varchar', length: 4, name: 'discriminator' })
   discriminator: string;
 
   @ApiProperty({

--- a/src/guilds-templates/dto/create-guild-template.dto.ts
+++ b/src/guilds-templates/dto/create-guild-template.dto.ts
@@ -1,21 +1,14 @@
 import { IsString, MaxLength, Length, IsOptional, IsJSON } from 'class-validator';
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
 import { IntersectionType } from '@nestjs/swagger';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 
-export class CreateGuildTemplateDto extends PickType(IntersectionType(PickableDiscordUUIDFields, PickableInternUUIDFields), [
-  'uuidGuild',
-  'uuidCategory'
+export class CreateGuildTemplateDto extends PickType(IntersectionType(PickableDiscordIdFields, PickableInternIdFields), [
+  'idGuildTemplate',
+  'idGuild',
+  'idCategory'
 ]) {
-  @ApiProperty({
-    description: 'ID Discord du template',
-    example: '123456789012345678'
-  })
-  @IsString()
-  @Length(17, 19)
-  uuid: string;
-
   @ApiProperty({
     description: 'Nom du template',
     example: 'Template Simplon'

--- a/src/guilds-templates/dto/update-guild-template.dto.ts
+++ b/src/guilds-templates/dto/update-guild-template.dto.ts
@@ -2,5 +2,5 @@ import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateGuildTemplateDto } from './create-guild-template.dto';
 
 export class UpdateGuildTemplateDto extends PartialType(
-  OmitType(CreateGuildTemplateDto, ['uuid'] as const),
+  OmitType(CreateGuildTemplateDto, ['idGuildTemplate'] as const),
 ) {}

--- a/src/guilds-templates/entities/guild-template.entity.ts
+++ b/src/guilds-templates/entities/guild-template.entity.ts
@@ -9,8 +9,8 @@ export class GuildTemplate {
     description: 'ID Discord du template',
     example: '123456789012345678'
   })
-  @PrimaryColumn({ type: 'varchar', length: 19, name: 'uuid_guild_template' })
-  uuid: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_guild_template' })
+  idGuildTemplate: string;
 
   @ApiProperty({
     description: 'Nom du template',
@@ -28,12 +28,12 @@ export class GuildTemplate {
   description: string;
 
   @ApiProperty({
-    description: 'UUID Discord du serveur associé',
+    description: 'id Discord du serveur associé',
     example: '123456789012345678',
     required: false
   })
-  @Column({ name: 'uuidGuild', type: 'varchar', length: 19, nullable: true })
-  uuidGuild: string;
+  @Column({ name: 'id_guild', type: 'varchar', length: 19, nullable: true })
+  idGuild: string;
 
   @ApiProperty({
     description: 'Configuration du template',
@@ -73,7 +73,7 @@ export class GuildTemplate {
     required: false
   })
   @OneToOne(() => Guild, guild => guild.template)
-  @JoinColumn({ name: 'uuidGuild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 
   @ApiProperty({
@@ -81,14 +81,14 @@ export class GuildTemplate {
     example: '123456789012345678',
     required: false
   })
-  @Column({ name: 'uuid_category', type: 'varchar', length: 19, nullable: true })
-  uuidCategory: string;
+  @Column({ name: 'id_category', type: 'varchar', length: 19, nullable: true })
+  idCategory: string;
 
   @ApiProperty({
     description: 'Catégorie associée à ce template',
     type: () => Category
   })
   @OneToOne(() => Category, category => category.guildTemplate)
-  @JoinColumn({ name: 'uuid_category' })
+  @JoinColumn({ name: 'id_category' })
   category: Category;
 }

--- a/src/guilds-templates/guilds-templates.controller.spec.ts
+++ b/src/guilds-templates/guilds-templates.controller.spec.ts
@@ -37,7 +37,7 @@ describe('GuildsTemplatesController', () => {
   describe('create', () => {
     it('should create a new guild template', async () => {
       const createDto = {
-        uuid: '123456789012345678',
+        idGuildTemplate: '123456789012345678',
         name: 'Test Template',
         description: 'Test Description',
         configuration: {
@@ -72,40 +72,40 @@ describe('GuildsTemplatesController', () => {
   });
 
   describe('findOne', () => {
-    it('should return a guild template by uuid', async () => {
-      const uuid = '123456789012345678';
+    it('should return a guild template by id', async () => {
+      const idGuildTemplate = '123456789012345678';
       const expectedResult = { id: 1, name: 'Template 1' };
       mockService.findOne.mockResolvedValue(expectedResult);
 
-      const result = await controller.findOne(uuid);
+      const result = await controller.findOne(idGuildTemplate);
 
-      expect(service.findOne).toHaveBeenCalledWith(uuid);
+      expect(service.findOne).toHaveBeenCalledWith(idGuildTemplate);
       expect(result).toEqual(expectedResult);
     });
   });
 
   describe('update', () => {
     it('should update a guild template', async () => {
-      const uuid = '123456789012345678';
+      const idGuildTemplate = '123456789012345678';
       const updateDto = { name: 'Updated Template' };
       const expectedResult = { id: 1, ...updateDto };
       mockService.update.mockResolvedValue(expectedResult);
 
-      const result = await controller.update(uuid, updateDto);
+      const result = await controller.update(idGuildTemplate, updateDto);
 
-      expect(service.update).toHaveBeenCalledWith(uuid, updateDto);
+      expect(service.update).toHaveBeenCalledWith(idGuildTemplate, updateDto);
       expect(result).toEqual(expectedResult);
     });
   });
 
   describe('remove', () => {
     it('should delete a guild template', async () => {
-      const uuid = '123456789012345678';
+      const idGuildTemplate = '123456789012345678';
       mockService.remove.mockResolvedValue(undefined);
 
-      await controller.remove(uuid);
+      await controller.remove(idGuildTemplate);
 
-      expect(service.remove).toHaveBeenCalledWith(uuid);
+      expect(service.remove).toHaveBeenCalledWith(idGuildTemplate);
     });
   });
 });

--- a/src/guilds-templates/guilds-templates.controller.ts
+++ b/src/guilds-templates/guilds-templates.controller.ts
@@ -25,31 +25,31 @@ export class GuildsTemplatesController {
     return this.guildsTemplatesService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer un template de serveur par son UUID' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer un template de serveur par son id' })
   @ApiResponse({ status: 200, description: 'Le template a été trouvé.', type: GuildTemplate })
   @ApiResponse({ status: 404, description: 'Template non trouvé' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.guildsTemplatesService.findOne(uuid);
+  findOne(@Param('id') idGuildTemplate: string) {
+    return this.guildsTemplatesService.findOne(idGuildTemplate);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour un template de serveur' })
   @ApiResponse({ status: 200, description: 'Le template a été mis à jour avec succès.', type: GuildTemplate })
   @ApiResponse({ status: 404, description: 'Template non trouvé' })
-  async update(@Param('uuid') uuid: string, @Body() updateGuildTemplateDto: UpdateGuildTemplateDto) {
-    const guildTemplate = await this.guildsTemplatesService.update(uuid, updateGuildTemplateDto);
+  async update(@Param('id') idGuildTemplate: string, @Body() updateGuildTemplateDto: UpdateGuildTemplateDto) {
+    const guildTemplate = await this.guildsTemplatesService.update(idGuildTemplate, updateGuildTemplateDto);
     if (!guildTemplate) {
-      throw new NotFoundException(`Guild template with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Guild template with id "${idGuildTemplate}" not found`);
     }
     return guildTemplate;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer un template de serveur' })
   @ApiResponse({ status: 200, description: 'Le template a été supprimé avec succès.' })
   @ApiResponse({ status: 404, description: 'Template non trouvé' })
-  remove(@Param('uuid') uuid: string) {
-    return this.guildsTemplatesService.remove(uuid);
+  remove(@Param('id') idGuildTemplate: string) {
+    return this.guildsTemplatesService.remove(idGuildTemplate);
   }
 }

--- a/src/guilds-templates/guilds-templates.service.spec.ts
+++ b/src/guilds-templates/guilds-templates.service.spec.ts
@@ -40,17 +40,24 @@ describe('GuildsTemplatesService', () => {
   describe('create', () => {
     it('should create a new guild template', async () => {
       const createDto = {
-        uuid: '123456789012345678',
+        idGuildTemplate: '123456789012345678',
+        idGuild: '123456789012345678',
+        idCategory: '123456789012345678',
         name: 'Test Template',
         description: 'Test Description',
         configuration: {
-          welcomeChannel: '123456789',
+          idWelcomeChannel: '123456789',
           prefix: '!',
           language: 'fr'
         }
       };
 
-      const newTemplate = { ...createDto, id: 1 };
+      const newTemplate = { 
+        ...createDto,
+        idGuildTemplate: '123456789012345678',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      };
       mockRepository.create.mockReturnValue(newTemplate);
       mockRepository.save.mockResolvedValue(newTemplate);
 
@@ -65,8 +72,18 @@ describe('GuildsTemplatesService', () => {
   describe('findAll', () => {
     it('should return an array of guild templates', async () => {
       const templates = [
-        { id: 1, name: 'Template 1' },
-        { id: 2, name: 'Template 2' },
+        { 
+          idGuildTemplate: '123456789012345678',
+          name: 'Template 1',
+          idGuild: '123456789012345678',
+          idCategory: '123456789012345678'
+        },
+        { 
+          idGuildTemplate: '123456789012345679',
+          name: 'Template 2',
+          idGuild: '123456789012345678',
+          idCategory: '123456789012345678'
+        }
       ];
       mockRepository.find.mockResolvedValue(templates);
 
@@ -80,15 +97,15 @@ describe('GuildsTemplatesService', () => {
   });
 
   describe('findOne', () => {
-    it('should return a guild template by uuid', async () => {
-      const template = { id: 1, name: 'Template 1' };
-      const uuid = '123456789012345678';
+    it('should return a guild template by id', async () => {
+      const template = { idGuildTemplate: '123456789012345678', name: 'Template 1' };
+      const idGuildTemplate = '123456789012345678';
       mockRepository.findOne.mockResolvedValue(template);
 
-      const result = await service.findOne(uuid);
+      const result = await service.findOne(idGuildTemplate);
 
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid },
+        where: { idGuildTemplate },
         relations: ['guild', 'category']
       });
       expect(result).toEqual(template);
@@ -97,20 +114,22 @@ describe('GuildsTemplatesService', () => {
 
   describe('update', () => {
     it('should update a guild template', async () => {
-      const uuid = '123456789012345678';
+      const idGuildTemplate = '123456789012345678';
       const updateDto = { name: 'Updated Template' };
       
-      // Créer un objet template existant
+      // Créer un objet template existant avec la bonne structure
       const existingTemplate = { 
-        id: 1, 
-        uuid: '123456789012345678',
+        idGuildTemplate: '123456789012345678',
         name: 'Test Template', 
         description: 'Test Description',
+        idGuild: '123456789012345678',
+        idCategory: '123456789012345678',
         configuration: {
-          language: 'fr',
+          idWelcomeChannel: '123456789',
           prefix: '!',
-          welcomeChannel: '123456789',
+          language: 'fr'
         },
+        createdAt: new Date(),
         updatedAt: new Date()
       };
       
@@ -120,33 +139,46 @@ describe('GuildsTemplatesService', () => {
       // Mock findOneBy pour retourner le template existant
       mockRepository.findOneBy.mockResolvedValue(existingTemplate);
       
-      // Mock save pour simuler la sauvegarde
-      mockRepository.save.mockImplementation((entity) => {
-        // Vérifier que l'entité a bien été mise à jour
-        expect(entity.name).toBe('Updated Template');
-        expect(entity.updatedAt).toBeInstanceOf(Date);
-        
-        // Retourner l'entité mise à jour
-        return Promise.resolve(entity);
-      });
+      // Créer l'objet mis à jour attendu
+      const updatedTemplate = {
+        ...existingTemplate,
+        name: 'Updated Template',
+        updatedAt: new Date()
+      };
+      
+      // Mock save pour retourner l'objet mis à jour
+      mockRepository.save.mockResolvedValue(updatedTemplate);
       
       // Appeler la méthode update
-      const result = await service.update(uuid, updateDto);
+      const result = await service.update(idGuildTemplate, updateDto);
       
-      // Vérifier que findOneBy a été appelé avec le bon uuid
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      // Vérifier que le résultat n'est pas null
+      expect(result).not.toBeNull();
       
-      // Vérifier que save a été appelé
-      expect(mockRepository.save).toHaveBeenCalled();
-      
-      // Vérifier que le résultat contient les bonnes valeurs
-      expect(result.name).toBe('Updated Template');
-      expect(result.description).toBe('Test Description');
-      expect(result.updatedAt).toBeInstanceOf(Date);
+      if (result) { // Type guard pour TypeScript
+        // Vérifier que findOneBy a été appelé avec le bon id
+        expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idGuildTemplate });
+        
+        // Vérifier que save a été appelé
+        expect(mockRepository.save).toHaveBeenCalled();
+        
+        // Vérifier que le résultat contient les bonnes valeurs
+        expect(result.name).toBe('Updated Template');
+        expect(result.description).toBe('Test Description');
+        expect(result.configuration.idWelcomeChannel).toBe('123456789');
+        expect(result.updatedAt).toBeInstanceOf(Date);
+        
+        // Vérifier que les autres propriétés n'ont pas été modifiées
+        expect(result.idGuildTemplate).toBe(existingTemplate.idGuildTemplate);
+        expect(result.idGuild).toBe(existingTemplate.idGuild);
+        expect(result.idCategory).toBe(existingTemplate.idCategory);
+        expect(result.configuration.prefix).toBe(existingTemplate.configuration.prefix);
+        expect(result.configuration.language).toBe(existingTemplate.configuration.language);
+      }
     });
-    
+
     it('should return null if template not found', async () => {
-      const uuid = '123456789012345678';
+      const idGuildTemplate = '123456789012345678';
       const updateDto = { name: 'Updated Template' };
       
       // Réinitialiser les mocks
@@ -155,21 +187,27 @@ describe('GuildsTemplatesService', () => {
       // Simuler le comportement du service
       mockRepository.findOneBy.mockResolvedValue(null);
 
-      const result = await service.update(uuid, updateDto);
+      const result = await service.update(idGuildTemplate, updateDto);
 
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      // Vérifier que findOneBy a été appelé avec le bon id
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idGuildTemplate });
+      
+      // Vérifier que le résultat est null
       expect(result).toBeNull();
+      
+      // Vérifier que save n'a pas été appelé
+      expect(mockRepository.save).not.toHaveBeenCalled();
     });
   });
 
   describe('remove', () => {
     it('should delete a guild template', async () => {
-      const uuid = '123456789012345678';
+      const idGuildTemplate = '123456789012345678';
       mockRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.remove(uuid);
+      await service.remove(idGuildTemplate);
 
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuid });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idGuildTemplate });
     });
   });
 });

--- a/src/guilds-templates/guilds-templates.service.ts
+++ b/src/guilds-templates/guilds-templates.service.ts
@@ -23,31 +23,31 @@ export class GuildsTemplatesService {
     });
   }
 
-  findOne(uuid: string) {
+  findOne(idGuildTemplate: string) {
     return this.guildTemplateRepository.findOne({
-      where: { uuid },
+      where: { idGuildTemplate },
       relations: ['guild', 'category']
     });
   }
 
-  async update(uuid: string, updateGuildTemplateDto: UpdateGuildTemplateDto) {
-    const guildTemplate = await this.guildTemplateRepository.findOneBy({ uuid });
+  async update(idGuildTemplate: string, updateGuildTemplateDto: UpdateGuildTemplateDto) {
+    const guildTemplate = await this.guildTemplateRepository.findOneBy({ idGuildTemplate });
     if (!guildTemplate) {
       return null;
     }
     
     // Mise à jour des champs autorisés uniquement
-    const { name, description, configuration, uuidCategory } = updateGuildTemplateDto;
+    const { name, description, configuration, idCategory } = updateGuildTemplateDto;
     if (name !== undefined) guildTemplate.name = name;
     if (description !== undefined) guildTemplate.description = description;
     if (configuration !== undefined) guildTemplate.configuration = configuration;
-    if (uuidCategory !== undefined) guildTemplate.uuidCategory = uuidCategory;
+    if (idCategory !== undefined) guildTemplate.idCategory = idCategory;
     
     guildTemplate.updatedAt = new Date();
     return this.guildTemplateRepository.save(guildTemplate);
   }
 
-  remove(uuid: string) {
-    return this.guildTemplateRepository.delete({ uuid });
+  remove(idGuildTemplate: string) {
+    return this.guildTemplateRepository.delete({ idGuildTemplate });
   }
 }

--- a/src/guilds/dto/create-guild.dto.ts
+++ b/src/guilds/dto/create-guild.dto.ts
@@ -1,15 +1,10 @@
 import { IsString, MaxLength, IsObject, Length } from 'class-validator';
-import { ApiProperty } from '@nestjs/swagger';
+import { ApiProperty,PickType } from '@nestjs/swagger';
+import { PickableDiscordIdFields } from 'src/utils/pickable-discord-id-fields';
 
-export class CreateGuildDto {
-  @ApiProperty({
-    description: 'ID Discord du serveur',
-    example: '123456789012345678'
-  })
-  @IsString()
-  @Length(17, 19)
-  uuid: string;
-
+export class CreateGuildDto extends PickType(PickableDiscordIdFields, [
+  'idGuild'
+]) {
   @ApiProperty({
     description: 'Nom du serveur',
     example: 'Simplon Server'

--- a/src/guilds/dto/update-guild.dto.ts
+++ b/src/guilds/dto/update-guild.dto.ts
@@ -2,5 +2,5 @@ import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateGuildDto } from './create-guild.dto';
 
 export class UpdateGuildDto extends PartialType(
-  OmitType(CreateGuildDto, ['uuid'] as const),
+  OmitType(CreateGuildDto, ['idGuild'] as const),
 ) {}

--- a/src/guilds/entities/guild.entity.ts
+++ b/src/guilds/entities/guild.entity.ts
@@ -15,8 +15,8 @@ export class Guild {
     description: 'ID Discord du serveur',
     example: '123456789012345678',
   })
-  @PrimaryColumn({ type: 'varchar', length: 19, name: 'uuid_guild' })
-  uuid: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_guild' })
+  idGuild: string;
 
   @ApiProperty({
     description: 'Nom du serveur',

--- a/src/guilds/guilds.controller.spec.ts
+++ b/src/guilds/guilds.controller.spec.ts
@@ -25,7 +25,7 @@ describe('GuildController', () => {
 
   it('should create a new guild', async () => {
     const dto: CreateGuildDto = {
-      uuid: '123456789012345678',
+      idGuild: '123456789012345678',
       name: 'Test Guild',
       memberCount: '10',
       configuration: {},
@@ -36,14 +36,14 @@ describe('GuildController', () => {
   });
 
   it('should return an array of guilds', async () => {
-    const result = [{ uuid: '123456789012345678', name: 'Test Guild', memberCount: '10', configuration: {} }];
+    const result = [{ idGuild: '123456789012345678', name: 'Test Guild', memberCount: '10', configuration: {} }];
     mockGuildService.findAll.mockResolvedValue(result);
     expect(await controller.findAll()).toEqual(result);
     expect(mockGuildService.findAll).toHaveBeenCalled();
   });
 
   it('should return a single guild', async () => {
-    const result = { uuid: '123456789012345678', name: 'Test Guild', memberCount: '10', configuration: {} };
+    const result = { idGuild: '123456789012345678', name: 'Test Guild', memberCount: '10', configuration: {} };
     mockGuildService.findOne.mockResolvedValue(result);
     expect(await controller.findOne('123456789012345678')).toEqual(result);
     expect(mockGuildService.findOne).toHaveBeenCalledWith('123456789012345678');
@@ -55,7 +55,7 @@ describe('GuildController', () => {
       memberCount: '15',
       configuration: { setting: true },
     };
-    const result = { uuid: '123456789012345678', name: 'Updated Guild', memberCount: '15', configuration: { setting: true } };
+    const result = { idGuild: '123456789012345678', name: 'Updated Guild', memberCount: '15', configuration: { setting: true } };
     mockGuildService.update.mockResolvedValue(result);
     expect(await controller.update('123456789012345678', dto)).toEqual(result);
     expect(mockGuildService.update).toHaveBeenCalledWith('123456789012345678', dto);

--- a/src/guilds/guilds.controller.ts
+++ b/src/guilds/guilds.controller.ts
@@ -25,31 +25,31 @@ export class GuildsController {
     return this.guildService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer un serveur Discord par son UUID' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer un serveur Discord par son id' })
   @ApiResponse({ status: 200, description: 'Le serveur a été trouvé.', type: Guild })
   @ApiResponse({ status: 404, description: 'Serveur non trouvé' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.guildService.findOne(uuid);
+  findOne(@Param('id') idGuild: string) {
+    return this.guildService.findOne(idGuild);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour un serveur Discord' })
   @ApiResponse({ status: 200, description: 'Le serveur a été mis à jour avec succès.', type: Guild })
   @ApiResponse({ status: 404, description: 'Serveur non trouvé' })
-  async update(@Param('uuid') uuid: string, @Body() updateGuildDto: UpdateGuildDto) {
-    const guild = await this.guildService.update(uuid, updateGuildDto);
+  async update(@Param('id') idGuild: string, @Body() updateGuildDto: UpdateGuildDto) {
+    const guild = await this.guildService.update(idGuild, updateGuildDto);
     if (!guild) {
-      throw new NotFoundException(`Guild with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Guild with id "${idGuild}" not found`);
     }
     return guild;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer un serveur Discord' })
   @ApiResponse({ status: 200, description: 'Le serveur a été supprimé avec succès.' })
   @ApiResponse({ status: 404, description: 'Serveur non trouvé' })
-  remove(@Param('uuid') uuid: string) {
-    return this.guildService.remove(uuid);
+  remove(@Param('id') idGuild: string) {
+    return this.guildService.remove(idGuild);
   }
 }

--- a/src/guilds/guilds.service.spec.ts
+++ b/src/guilds/guilds.service.spec.ts
@@ -4,14 +4,6 @@ import { Repository } from 'typeorm';
 import { Guild } from './entities/guild.entity';
 import { CreateGuildDto } from './dto/create-guild.dto';
 import { UpdateGuildDto } from './dto/update-guild.dto';
-import { Course } from '../courses/entities/course.entity';
-import { Member } from '../members/entities/member.entity';
-import { Role } from '../roles/entities/role.entity';
-import { Channel } from '../channels/entities/channel.entity';
-import { Category } from '../categories/entities/category.entity';
-import { Campus } from '../campuses/entities/campus.entity';
-import { Promotion } from '../promotions/entities/promotion.entity';
-import { GuildTemplate } from '../guilds-templates/entities/guild-template.entity';
 
 const mockRepository = {
   create: vi.fn(),
@@ -26,7 +18,7 @@ describe('GuildsService', () => {
   let service: GuildsService;
 
   const mockGuild = {
-    uuid: '123456789012345678',
+    idGuild: '123456789012345678',
     name: 'Test Guild',
     memberCount: '10',
     configuration: {},
@@ -35,20 +27,20 @@ describe('GuildsService', () => {
   };
 
   const mockCourse = {
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    idCourse: '123e4567-e89b-12d3-a456-426614174000',
     name: 'Test Course',
     isCertified: true,
   };
 
   const mockMember = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+    idMember: '123e4567-e89b-12d3-a456-426614174001',
     guildUsername: 'TestUser',
     xp: '100.00',
     level: 1,
   };
 
   const mockRole = {
-    uuidRole: '234567890123456789',
+    idRole: '234567890123456789',
     name: 'Test Role',
     memberCount: 1,
   };
@@ -65,7 +57,7 @@ describe('GuildsService', () => {
   describe('create', () => {
     it('should create a new guild', async () => {
       const dto: CreateGuildDto = {
-        uuid: '123456789012345678',
+        idGuild: '123456789012345678',
         name: 'Test Guild',
         memberCount: '10',
         configuration: {},
@@ -113,7 +105,7 @@ describe('GuildsService', () => {
 
       expect(result).toEqual(guildWithRelations);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: '123456789012345678' },
+        where: { idGuild: '123456789012345678' },
         relations: ['courses', 'members', 'roles', 'channels', 'categories', 'campuses', 'promotions', 'template']
       });
     });
@@ -141,7 +133,7 @@ describe('GuildsService', () => {
 
       expect(result).toEqual(updatedGuild);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: '123456789012345678' },
+        where: { idGuild: '123456789012345678' },
         relations: ['courses', 'members', 'roles', 'channels', 'categories', 'campuses', 'promotions', 'template']
       });
       expect(mockRepository.save).toHaveBeenCalledWith(updatedGuild);
@@ -152,7 +144,7 @@ describe('GuildsService', () => {
     it('should delete a guild and cascade delete related entities', async () => {
       mockRepository.delete.mockResolvedValue({ affected: 1 });
       await service.remove('123456789012345678');
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuid: '123456789012345678' });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idGuild: '123456789012345678' });
     });
   });
 });

--- a/src/guilds/guilds.service.ts
+++ b/src/guilds/guilds.service.ts
@@ -25,23 +25,23 @@ export class GuildsService {
     });
   }
 
-  // Récupérer une guild par son uuid
-  async findOne(uuid: string): Promise<Guild> {
+  // Récupérer une guild par son sf
+  async findOne(idGuild: string): Promise<Guild> {
     const guild = await this.guildRepository.findOne({
-      where: { uuid },
+      where: { idGuild },
       relations: ['courses', 'members', 'roles', 'channels', 'categories', 'campuses', 'promotions', 'template']
     });
 
     if (!guild) {
-      throw new NotFoundException(`Guild with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Guild with id "${idGuild}" not found`);
     }
 
     return guild;
   }
 
   // Mettre à jour une guild
-  async update(uuid: string, updateGuildDto: UpdateGuildDto): Promise<Guild> {
-    const guild = await this.findOne(uuid);
+  async update(idGuild: string, updateGuildDto: UpdateGuildDto): Promise<Guild> {
+    const guild = await this.findOne(idGuild);
     
     // Mise à jour des propriétés simples
     Object.assign(guild, updateGuildDto);
@@ -50,11 +50,11 @@ export class GuildsService {
   }
 
   // Supprimer une guild
-  async remove(uuid: string): Promise<void> {
-    const result = await this.guildRepository.delete({ uuid });
+  async remove(idGuild: string): Promise<void> {
+    const result = await this.guildRepository.delete({ idGuild });
     
     if (result.affected === 0) {
-      throw new NotFoundException(`Guild with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Guild with id "${idGuild}" not found`);
     }
   }
 }

--- a/src/identification-requests/dto/create-identification-request.dto.ts
+++ b/src/identification-requests/dto/create-identification-request.dto.ts
@@ -1,22 +1,13 @@
-import { PickType } from '@nestjs/swagger';
+import { PickType, IntersectionType } from '@nestjs/swagger';
 import { IsString, IsEmail, Length } from 'class-validator';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
+import { PickableDtoFields } from 'src/utils/pickable-dto-fields';
 
-export class CreateIdentificationRequestDto extends PickType(PickableInternUUIDFields, [
-    'uuidMember'
+export class CreateIdentificationRequestDto extends PickType(IntersectionType(PickableInternIdFields, PickableDtoFields), [
+    'idMember',
+    'firstName',
+    'lastName',
+    'email'
 ]) {
-
-  @IsString()
-  @Length(2, 50)
-  firstname: string;
-
-  @IsString()
-  @Length(2, 50)
-  lastname: string;
-
-  @IsEmail()
-  email: string;
-
-  uuidMember: string; 
 
 }

--- a/src/identification-requests/entities/identification-request.entity.ts
+++ b/src/identification-requests/entities/identification-request.entity.ts
@@ -6,24 +6,24 @@ import { Member } from "src/members/entities/member.entity";
 export class IdentificationRequest {
     
     @PrimaryGeneratedColumn('uuid', {
-        name: 'uuid_identification_request',
+        name: 'id_identification_request',
     })
-    uuid: string;
+    idIdentificationRequest: string;
 
     @Column({type: 'varchar', length: 50})
-    firstname: string
+    firstName: string
 
     @Column({type: 'varchar', length: 50})
-    lastname: string
+    lastName: string
 
     @Column({type: 'varchar', length: 50})
     email: string
 
-    @Column({ type: 'uuid', name: 'uuidMember' })
-    uuidMember: string;
+    @Column({ type: 'uuid', name: 'id_member' })
+    idMember: string;
 
     @OneToOne(() => Member, (member) => member.identificationRequest)
-    @JoinColumn({ name: 'uuidMember' })
+    @JoinColumn({ name: 'id_member' })
     member: Member
 
 }

--- a/src/identification-requests/identification-requests.controller.spec.ts
+++ b/src/identification-requests/identification-requests.controller.spec.ts
@@ -25,26 +25,26 @@ describe('IdentificationRequestsController', () => {
 
   it('should create a new identification request', async () => {
     const dto: CreateIdentificationRequestDto = {
-      uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+      idMember: '123e4567-e89b-12d3-a456-426614174000',
       firstname: 'John',
       lastname: 'Doe',
       email: 'john.doe@example.com',
     };
-    const result = { ...dto, uuid: '123e4567-e89b-12d3-a456-426614174001' };
+    const result = { ...dto, idMember: '123e4567-e89b-12d3-a456-426614174001' };
     mockIdentificationRequestsService.create.mockResolvedValue(result);
     expect(await controller.create(dto)).toEqual(result);
     expect(mockIdentificationRequestsService.create).toHaveBeenCalledWith(dto);
   });
 
   it('should return an array of identification requests', async () => {
-    const result = [{ uuid: '123e4567-e89b-12d3-a456-426614174000', uuidMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' }];
+    const result = [{ uuid: '123e4567-e89b-12d3-a456-426614174000', idMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' }];
     mockIdentificationRequestsService.findAll.mockResolvedValue(result);
     expect(await controller.findAll()).toEqual(result);
     expect(mockIdentificationRequestsService.findAll).toHaveBeenCalled();
   });
 
   it('should return a single identification request', async () => {
-    const result = { uuid: '123e4567-e89b-12d3-a456-426614174000', uuidMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' };
+    const result = { uuid: '123e4567-e89b-12d3-a456-426614174000', idMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' };
     mockIdentificationRequestsService.findOne.mockResolvedValue(result);
     expect(await controller.findOne('123e4567-e89b-12d3-a456-426614174000')).toEqual(result);
     expect(mockIdentificationRequestsService.findOne).toHaveBeenCalledWith('123e4567-e89b-12d3-a456-426614174000');
@@ -52,7 +52,7 @@ describe('IdentificationRequestsController', () => {
 
   it('should update an identification request', async () => {
     const dto: UpdateIdentificationRequestDto = { firstname: 'Jane' };
-    const result = { uuid: '123e4567-e89b-12d3-a456-426614174000', uuidMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'Jane', lastname: 'Doe', email: 'john.doe@example.com' };
+    const result = { uuid: '123e4567-e89b-12d3-a456-426614174000', idMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'Jane', lastname: 'Doe', email: 'john.doe@example.com' };
     mockIdentificationRequestsService.update.mockResolvedValue(result);
     expect(await controller.update('123e4567-e89b-12d3-a456-426614174000', dto)).toEqual(result);
     expect(mockIdentificationRequestsService.update).toHaveBeenCalledWith('123e4567-e89b-12d3-a456-426614174000', dto);

--- a/src/identification-requests/identification-requests.controller.ts
+++ b/src/identification-requests/identification-requests.controller.ts
@@ -17,22 +17,22 @@ export class IdentificationRequestsController {
     return this.identificationRequestsService.findAll();
   }
 
-  @Get(':uuid')
-  findOne(@Param('uuid') uuid: string) {
-    return this.identificationRequestsService.findOne(uuid);
+  @Get(':id')
+  findOne(@Param('id') idIdentificationRequest: string) {
+    return this.identificationRequestsService.findOne(idIdentificationRequest);
   }
 
-  @Put(':uuid')
-  async update(@Param('uuid') uuid: string, @Body() updateIdentificationRequestDto: UpdateIdentificationRequestDto) {
-    const identificationRequest = await this.identificationRequestsService.update(uuid, updateIdentificationRequestDto);
+  @Put(':id')
+  async update(@Param('id') idIdentificationRequest: string, @Body() updateIdentificationRequestDto: UpdateIdentificationRequestDto) {
+    const identificationRequest = await this.identificationRequestsService.update(idIdentificationRequest, updateIdentificationRequestDto);
     if (!identificationRequest) {
-      throw new NotFoundException(`IdentificationRequest with UUID "${uuid}" not found`);
+      throw new NotFoundException(`IdentificationRequest with id "${idIdentificationRequest}" not found`);
     }
     return identificationRequest;
   }
 
-  @Delete(':uuid')
-  remove(@Param('uuid') uuid: string) {
-    return this.identificationRequestsService.remove(uuid);
+  @Delete(':id')
+  remove(@Param('id') idIdentificationRequest: string) {
+    return this.identificationRequestsService.remove(idIdentificationRequest);
   }
 }

--- a/src/identification-requests/identification-requests.service.spec.ts
+++ b/src/identification-requests/identification-requests.service.spec.ts
@@ -26,12 +26,12 @@ describe('IdentificationRequestsService', () => {
 
   it('should create a new identification request', async () => {
     const dto: CreateIdentificationRequestDto = {
-      uuidMember: '123e4567-e89b-12d3-a456-426614174000',
-      firstname: 'John',
-      lastname: 'Doe',
+      idMember: '123e4567-e89b-12d3-a456-426614174000',
+      firstName: 'John',
+      lastName: 'Doe',
       email: 'john.doe@example.com',
     };
-    const entity = { ...dto, uuid: '123e4567-e89b-12d3-a456-426614174001' };
+    const entity = { ...dto };
     mockRepository.create.mockReturnValue(entity);
     mockRepository.save.mockResolvedValue(entity);
 
@@ -41,34 +41,56 @@ describe('IdentificationRequestsService', () => {
   });
 
   it('should return an array of identification requests', async () => {
-    const result = [{ uuid: '123e4567-e89b-12d3-a456-426614174000', uuidMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' }];
+    const result = [{ uuid: '123e4567-e89b-12d3-a456-426614174000', idIdentificationRequest: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' }];
     mockRepository.find.mockResolvedValue(result);
     expect(await service.findAll()).toEqual(result);
     expect(mockRepository.find).toHaveBeenCalled();
   });
 
   it('should return a single identification request', async () => {
-    const result = { uuid: '123e4567-e89b-12d3-a456-426614174000', uuidMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'John', lastname: 'Doe', email: 'john.doe@example.com' };
-    mockRepository.findOneBy.mockResolvedValue(result);
-    expect(await service.findOne('123e4567-e89b-12d3-a456-426614174000')).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: '123e4567-e89b-12d3-a456-426614174000' });
+    const mockIdentificationRequest = {
+      idIdentificationRequest: '123e4567-e89b-12d3-a456-426614174000',
+      idMember: '123e4567-e89b-12d3-a456-426614174000',
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john.doe@example.com'
+    };
+    mockRepository.findOneBy.mockResolvedValue(mockIdentificationRequest);
+    expect(await service.findOne('123e4567-e89b-12d3-a456-426614174000')).toEqual(mockIdentificationRequest);
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ 
+      idIdentificationRequest: '123e4567-e89b-12d3-a456-426614174000' 
+    });
   });
 
   it('should update an identification request', async () => {
-    const dto: UpdateIdentificationRequestDto = { firstname: 'Jane' };
-    const result = { uuid: '123e4567-e89b-12d3-a456-426614174000', uuidMember: '123e4567-e89b-12d3-a456-426614174000', firstname: 'Jane', lastname: 'Doe', email: 'john.doe@example.com' };
-    mockRepository.findOneBy.mockResolvedValue(result);
-    mockRepository.save.mockResolvedValue(result);
+    const dto: UpdateIdentificationRequestDto = { firstName: 'Jane' };
+    const mockIdentificationRequest = {
+      idIdentificationRequest: '123e4567-e89b-12d3-a456-426614174000',
+      idMember: '123e4567-e89b-12d3-a456-426614174000',
+      firstName: 'John',
+      lastName: 'Doe',
+      email: 'john.doe@example.com'
+    };
+    const updatedRequest = { 
+      ...mockIdentificationRequest,
+      firstName: 'Jane'
+    };
+    mockRepository.findOneBy.mockResolvedValue(mockIdentificationRequest);
+    mockRepository.save.mockResolvedValue(updatedRequest);
 
-    expect(await service.update('123e4567-e89b-12d3-a456-426614174000', dto)).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: '123e4567-e89b-12d3-a456-426614174000' });
-    expect(mockRepository.save).toHaveBeenCalledWith(result);
+    expect(await service.update('123e4567-e89b-12d3-a456-426614174000', dto)).toEqual(updatedRequest);
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ 
+      idIdentificationRequest: '123e4567-e89b-12d3-a456-426614174000' 
+    });
+    expect(mockRepository.save).toHaveBeenCalledWith(updatedRequest);
   });
 
   it('should delete an identification request', async () => {
     mockRepository.delete.mockResolvedValue({ affected: 1 });
     expect(await service.remove('123e4567-e89b-12d3-a456-426614174000')).toEqual({ affected: 1 });
-    expect(mockRepository.delete).toHaveBeenCalledWith('123e4567-e89b-12d3-a456-426614174000');
+    expect(mockRepository.delete).toHaveBeenCalledWith({
+      idIdentificationRequest: '123e4567-e89b-12d3-a456-426614174000'
+    });
   });
 });
 

--- a/src/identification-requests/identification-requests.service.ts
+++ b/src/identification-requests/identification-requests.service.ts
@@ -22,12 +22,12 @@ export class IdentificationRequestsService {
     return this.identificationRequestsRepository.find();
   }
 
-  findOne(uuid: string) {
-    return this.identificationRequestsRepository.findOneBy({ uuid });
+  findOne(idIdentificationRequest: string) {
+    return this.identificationRequestsRepository.findOneBy({ idIdentificationRequest });
   }
 
-  async update(uuid: string, updateIdentificationRequestDto: UpdateIdentificationRequestDto) {
-    const identificationRequest = await this.identificationRequestsRepository.findOneBy({ uuid });
+  async update(idIdentificationRequest: string, updateIdentificationRequestDto: UpdateIdentificationRequestDto) {
+    const identificationRequest = await this.identificationRequestsRepository.findOneBy({ idIdentificationRequest });
   
     if (!identificationRequest) {
       return null;
@@ -35,15 +35,15 @@ export class IdentificationRequestsService {
   
     Object.assign(identificationRequest, updateIdentificationRequestDto);
   
-    if (updateIdentificationRequestDto.uuidMember !== undefined) {
-      identificationRequest.uuidMember = updateIdentificationRequestDto.uuidMember;
+    if (updateIdentificationRequestDto.idMember !== undefined) {
+      identificationRequest.idMember = updateIdentificationRequestDto.idMember;
     }
   
     return this.identificationRequestsRepository.save(identificationRequest);
   }
   
 
-  remove(uuid: string) {
-    return this.identificationRequestsRepository.delete(uuid);
+  remove(idIdentificationRequest: string) {
+    return this.identificationRequestsRepository.delete(idIdentificationRequest);
   }
 }

--- a/src/members-informations/dto/create-member-informations.dto.ts
+++ b/src/members-informations/dto/create-member-informations.dto.ts
@@ -1,34 +1,14 @@
 import { IsString, IsEmail, MaxLength } from 'class-validator';
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
+import { PickableDtoFields } from 'src/utils/pickable-dto-fields';
 
-export class CreateMemberInformationsDto extends PickType(PickableInternUUIDFields, [
-    'uuidMember'
+export class CreateMemberInformationsDto extends PickType(IntersectionType(PickableInternIdFields, PickableDtoFields), [
+    'idMemberInfos',
+    'idMember',
+    'firstName',
+    'lastName',
+    'email'
 ]) {
 
-    @ApiProperty({
-        description: 'Prénom du membre',
-        example: 'Jean'
-    })
-    @IsString()
-    @MaxLength(50)
-    firstName: string;
-
-    @ApiProperty({
-        description: 'Nom de famille du membre',
-        example: 'Dupont'
-    })
-    @IsString()
-    @MaxLength(50)
-    lastName: string;
-
-    @ApiProperty({
-        description: 'Adresse email du membre',
-        example: 'jean.dupont@example.com'
-    })
-    @IsEmail()
-    @MaxLength(100)
-    email: string;
-
-    uuidMember: string;
 }

--- a/src/members-informations/entities/member-information.entity.ts
+++ b/src/members-informations/entities/member-information.entity.ts
@@ -9,8 +9,8 @@ export class MemberInformation {
     description: 'UUID unique des informations du membre',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_members_infos' })
-  uuid: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_members_infos' })
+  idMemberInfos: string;
 
   @ApiProperty({
     description: 'Prénom du membre',
@@ -46,7 +46,7 @@ export class MemberInformation {
   updatedAt: Date;
 
   @OneToOne(() => Member, (member) => member.memberInformation)
-  @JoinColumn({ name: 'uuidMember' })
+  @JoinColumn({ name: 'id_member' })
   member: Member;
 
 } 

--- a/src/members-informations/members-informations.controller.spec.ts
+++ b/src/members-informations/members-informations.controller.spec.ts
@@ -29,7 +29,7 @@ describe('MembersInformationsController', () => {
 
   it('should create a new member information', async () => {
     const dto: CreateMemberInformationsDto = {
-      uuidMember: '123e4567-e89b-12d3-a456-4266141740000000',
+      idMemberInfos: '123e4567-e89b-12d3-a456-4266141740000000',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john.doe@example.com',

--- a/src/members-informations/members-informations.controller.ts
+++ b/src/members-informations/members-informations.controller.ts
@@ -25,31 +25,31 @@ export class MembersInformationsController {
     return this.membersInformationsService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer les informations d\'un membre par son UUID' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer les informations d\'un membre par son id' })
   @ApiResponse({ status: 200, description: 'Les informations ont été trouvées.', type: MemberInformation })
   @ApiResponse({ status: 404, description: 'Informations non trouvées' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.membersInformationsService.findOne(uuid);
+  findOne(@Param('id') idMemberInfos: string) {
+    return this.membersInformationsService.findOne(idMemberInfos);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour les informations d\'un membre' })
   @ApiResponse({ status: 200, description: 'Les informations ont été mises à jour avec succès.', type: MemberInformation })
   @ApiResponse({ status: 404, description: 'Informations non trouvées' })
-  async update(@Param('uuid') uuid: string, @Body() updateMemberInformationsDto: UpdateMemberInformationsDto) {
-    const memberInformations = await this.membersInformationsService.update(uuid, updateMemberInformationsDto);
+  async update(@Param('id') idMemberInfos: string, @Body() updateMemberInformationsDto: UpdateMemberInformationsDto) {
+    const memberInformations = await this.membersInformationsService.update(idMemberInfos, updateMemberInformationsDto);
     if (!memberInformations) {
-      throw new NotFoundException(`MemberInformations with UUID "${uuid}" not found`);
+      throw new NotFoundException(`MemberInformations with id "${idMemberInfos}" not found`);
     }
     return memberInformations;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer les informations d\'un membre' })
   @ApiResponse({ status: 200, description: 'Les informations ont été supprimées avec succès.' })
   @ApiResponse({ status: 404, description: 'Informations non trouvées' })
-  remove(@Param('uuid') uuid: string) {
-    return this.membersInformationsService.remove(uuid);
+  remove(@Param('id') idMemberInfos: string) {
+    return this.membersInformationsService.remove(idMemberInfos);
   }
 }

--- a/src/members-informations/members-informations.service.spec.ts
+++ b/src/members-informations/members-informations.service.spec.ts
@@ -45,7 +45,7 @@ describe('MembersInformationsService', () => {
     };
     const entity = { 
       ...dto, 
-      uuid: '123e4567-e89b-12d3-a456-426614174000',
+      idMemberInfos: '123e4567-e89b-12d3-a456-426614174000',
       createdAt: new Date(),
       updatedAt: new Date()
     };
@@ -58,7 +58,7 @@ describe('MembersInformationsService', () => {
 
   it('should return an array of members informations', async () => {
     const result = [{
-      uuid: '123e4567-e89b-12d3-a456-426614174000',
+      idMemberInfos: '123e4567-e89b-12d3-a456-426614174000',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john.doe@example.com',
@@ -73,7 +73,7 @@ describe('MembersInformationsService', () => {
 
   it('should return a single member information', async () => {
     const result = {
-      uuid: '123e4567-e89b-12d3-a456-426614174000',
+      idMemberInfos: '123e4567-e89b-12d3-a456-426614174000',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john.doe@example.com',
@@ -83,13 +83,13 @@ describe('MembersInformationsService', () => {
     mockRepository.findOneBy.mockResolvedValue(result);
 
     expect(await service.findOne('123e4567-e89b-12d3-a456-426614174000')).toEqual(result);
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: '123e4567-e89b-12d3-a456-426614174000' });
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idMemberInfos: '123e4567-e89b-12d3-a456-426614174000' });
   });
 
   it('should update a member information', async () => {
     const dto: UpdateMemberInformationsDto = { firstName: 'Jane' };
     const existingMemberInfo = {
-      uuid: '123e4567-e89b-12d3-a456-426614174000',
+      idMemberInfos: '123e4567-e89b-12d3-a456-426614174000',
       firstName: 'John',
       lastName: 'Doe',
       email: 'john.doe@example.com',
@@ -122,8 +122,8 @@ describe('MembersInformationsService', () => {
     // Appeler la méthode update
     const result = await service.update('123e4567-e89b-12d3-a456-426614174000', dto);
     
-    // Vérifier que findOneBy a été appelé avec le bon uuid
-    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuid: '123e4567-e89b-12d3-a456-426614174000' });
+    // Vérifier que findOneBy a été appelé avec le bon id
+    expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idMemberInfos: '123e4567-e89b-12d3-a456-426614174000' });
     
     // Vérifier que save a été appelé
     expect(mockRepository.save).toHaveBeenCalled();

--- a/src/members-informations/members-informations.service.ts
+++ b/src/members-informations/members-informations.service.ts
@@ -20,12 +20,12 @@ export class MembersInformationsService {
     return this.memberInformationsRepository.find();
   }
 
-  findOne(uuid: string) {
-    return this.memberInformationsRepository.findOneBy({ uuid });
+  findOne(idMemberInfos: string) {
+    return this.memberInformationsRepository.findOneBy({ idMemberInfos });
   }
 
-  async update(uuid: string, updateMemberInformationDto: UpdateMemberInformationsDto) {
-    const memberInfo = await this.memberInformationsRepository.findOneBy({ uuid });
+  async update(idMemberInfos: string, updateMemberInformationDto: UpdateMemberInformationsDto) {
+    const memberInfo = await this.memberInformationsRepository.findOneBy({ idMemberInfos });
     if (!memberInfo) {
       return null;
     }
@@ -40,7 +40,7 @@ export class MembersInformationsService {
     return this.memberInformationsRepository.save(memberInfo);
   }
 
-  remove(uuid: string) {
-    return this.memberInformationsRepository.delete(uuid);
+  remove(idMemberInfos: string) {
+    return this.memberInformationsRepository.delete(idMemberInfos);
   }
 }

--- a/src/members/dto/create-member.dto.ts
+++ b/src/members/dto/create-member.dto.ts
@@ -1,11 +1,13 @@
-import { IsString, MaxLength, IsInt, Min, Matches, IsIn } from 'class-validator';
-import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
-
-export class CreateMemberDto extends PickType(PickableDiscordUUIDFields, [
-  'uuidDiscord',
-  'uuidGuild'
-]) {
+import { IsString, MaxLength, IsInt, Min, Matches, IsIn, IsUUID } from 'class-validator';
+import { ApiProperty, PickType, IntersectionType } from '@nestjs/swagger';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
+ 
+export class CreateMemberDto extends PickType(IntersectionType(PickableInternIdFields, PickableDiscordIdFields), [
+  'idMember',
+  'idDiscord',
+  'idGuild'
+]) {     
   @ApiProperty({
     description: 'Nom d\'utilisateur du membre dans la guilde',
     example: 'JohnDoe',

--- a/src/members/entities/member.entity.ts
+++ b/src/members/entities/member.entity.ts
@@ -20,8 +20,8 @@ export class Member {
     description: 'UUID unique du membre',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_member' })
-  uuidMember: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_member' })
+  idMember: string;
 
   @ApiProperty({
     description: 'Nom d\'utilisateur du membre dans la guilde',
@@ -76,21 +76,21 @@ export class Member {
     description: 'UUID de la guilde',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ type: 'uuid', name: 'uuid_guild' })
-  uuidGuild: string;
+  @Column({ type: 'uuid', name: 'id_guild' })
+  idGuild: string;
 
   @ApiProperty({
     description: 'Relation avec la guilde'
   })
   @ManyToOne(() => Guild, (guild) => guild.members, { lazy: true })
-  @JoinColumn({ name: 'uuid_guild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Promise<Guild>;
 
-  @Column({ type: 'uuid', name: 'uuid_discord' }) 
-  uuidDiscord: string;
+  @Column({ type: 'uuid', name: 'id_discord' }) 
+  idDiscord: string;
 
   @OneToOne(() => DiscordUser, (discordUser) => discordUser.member)
-  @JoinColumn({ name: 'uuid_discord' })
+  @JoinColumn({ name: 'id_discord' })
   discordUser: DiscordUser;
 
   @OneToOne(() => MemberInformation, (memberInformation) => memberInformation.member)

--- a/src/members/members.controller.spec.ts
+++ b/src/members/members.controller.spec.ts
@@ -11,7 +11,7 @@ describe('MembersController', () => {
   let membersService: MembersService;
 
   const mockGuild: Guild = {
-    uuid: '123e4567-e89b-12d3-a456-426614174001',
+    idGuild: '123e4567-e89b-12d3-a456-426614174001',
     name: 'Test Guild',
     memberCount: 10,
     configuration: {},
@@ -20,15 +20,15 @@ describe('MembersController', () => {
   };
 
   const mockMember: Member = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174000',
-    guild_username: 'TestUser',
+    idMember: '123e4567-e89b-12d3-a456-426614174000',
+    guildUsername: 'TestUser',
     xp: '100.00',
     level: 1,
-    community_role: 'Member',
+    communityRole: 'Member',
     status: 'Active',
     createdAt: new Date(),
     updatedAt: new Date(),
-    uuidDiscord: '123e4567-e89b-12d3-a456-426614174002',
+    idDiscord: '123e4567-e89b-12d3-a456-426614174002',
     guild: mockGuild
   };
 
@@ -47,13 +47,13 @@ describe('MembersController', () => {
   describe('create', () => {
     it('devrait créer un nouveau membre', async () => {
       const createMemberDto: CreateMemberDto = {
-        guild_username: 'TestUser',
+        guildUsername: 'TestUser',
         xp: '100.00',
         level: 1,
-        community_role: 'Member',
+        communityRole: 'Member',
         status: 'Active',
-        uuidGuild: '123e4567-e89b-12d3-a456-426614174001',
-        uuidDiscord: '123e4567-e89b-12d3-a456-426614174002'
+        idGuild: '123e4567-e89b-12d3-a456-426614174001',
+        idDiscord: '123e4567-e89b-12d3-a456-426614174002'
       };
 
       vi.mocked(membersService.create).mockResolvedValue(mockMember);
@@ -78,30 +78,30 @@ describe('MembersController', () => {
   });
 
   describe('findOne', () => {
-    it('devrait retourner un membre par son uuid', async () => {
+    it('devrait retourner un membre par son id', async () => {
       vi.mocked(membersService.findOne).mockResolvedValue(mockMember);
 
-      const result = await controller.findOne(mockMember.uuidMember);
+      const result = await controller.findOne(mockMember.idMember);
 
       expect(result).toEqual(mockMember);
-      expect(membersService.findOne).toHaveBeenCalledWith(mockMember.uuidMember);
+      expect(membersService.findOne).toHaveBeenCalledWith(mockMember.idMember);
     });
   });
 
   describe('update', () => {
     it('devrait mettre à jour un membre', async () => {
       const updateMemberDto: UpdateMemberDto = {
-        guild_username: 'UpdatedUser',
+        guildUsername: 'UpdatedUser',
         status: 'Inactive'
       };
       const updatedMember = { ...mockMember, ...updateMemberDto };
 
       vi.mocked(membersService.update).mockResolvedValue(updatedMember);
 
-      const result = await controller.update(mockMember.uuidMember, updateMemberDto);
+      const result = await controller.update(mockMember.idMember, updateMemberDto);
 
       expect(result).toEqual(updatedMember);
-      expect(membersService.update).toHaveBeenCalledWith(mockMember.uuidMember, updateMemberDto);
+      expect(membersService.update).toHaveBeenCalledWith(mockMember.idMember, updateMemberDto);
     });
   });
 
@@ -109,10 +109,10 @@ describe('MembersController', () => {
     it('devrait supprimer un membre', async () => {
       vi.mocked(membersService.remove).mockResolvedValue(undefined);
 
-      const result = await controller.remove(mockMember.uuidMember);
+      const result = await controller.remove(mockMember.idMember);
 
       expect(result).toBeUndefined();
-      expect(membersService.remove).toHaveBeenCalledWith(mockMember.uuidMember);
+      expect(membersService.remove).toHaveBeenCalledWith(mockMember.idMember);
     });
   });
 });

--- a/src/members/members.controller.ts
+++ b/src/members/members.controller.ts
@@ -65,15 +65,15 @@ export class MembersController {
     return this.membersService.findAll();
   }
 
-  @Get(':uuid')
+  @Get(':id')
   @ApiOperation({
-    summary: 'Récupérer un membre par son UUID',
+    summary: 'Récupérer un membre par son id',
     description:
-      'Recherche et retourne un membre spécifique en utilisant son UUID.',
+      'Recherche et retourne un membre spécifique en utilisant son id.',
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID unique du membre à rechercher',
+    name: 'id',
+    description: 'id unique du membre à rechercher',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
@@ -83,21 +83,21 @@ export class MembersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: "Aucun membre trouvé avec l'UUID fourni.",
+    description: "Aucun membre trouvé avec l'id fourni.",
   })
-  findOne(@Param('uuid') uuid: string) {
-    return this.membersService.findOne(uuid);
+  findOne(@Param('id') idMember: string) {
+    return this.membersService.findOne(idMember);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({
     summary: 'Mettre à jour un membre',
     description:
-      "Met à jour les informations d'un membre existant en utilisant son UUID.",
+      "Met à jour les informations d'un membre existant en utilisant son id.",
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID unique du membre à mettre à jour',
+    name: 'id',
+    description: 'id unique du membre à mettre à jour',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiBody({ type: UpdateMemberDto })
@@ -112,24 +112,24 @@ export class MembersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: "Aucun membre trouvé avec l'UUID fourni.",
+    description: "Aucun membre trouvé avec l'id fourni.",
   })
   update(
-    @Param('uuid') uuid: string,
+    @Param('id') idMember: string,
     @Body() updateMemberDto: UpdateMemberDto,
   ) {
-    return this.membersService.update(uuid, updateMemberDto);
+    return this.membersService.update(idMember, updateMemberDto);
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({
     summary: 'Supprimer un membre',
     description:
-      'Supprime un membre existant de la base de données en utilisant son UUID.',
+      'Supprime un membre existant de la base de données en utilisant son id.',
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID unique du membre à supprimer',
+    name: 'id',
+    description: 'id unique du membre à supprimer',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
@@ -138,15 +138,15 @@ export class MembersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: "Aucun membre trouvé avec l'UUID fourni.",
+    description: "Aucun membre trouvé avec l'id fourni.",
   })
-  remove(@Param('uuid') uuid: string) {
-    return this.membersService.remove(uuid);
+  remove(@Param('id') idMember: string) {
+    return this.membersService.remove(idMember);
   }
 
-  @Get(':uuid_member/roles')
+  @Get(':id/roles')
   @ApiOperation({ summary: 'Récupérer tous les rôles liés à un membre' })
-  @ApiParam({ name: 'uuid_member', description: 'UUID du membre' })
+  @ApiParam({ name: 'idMember', description: 'id du membre' })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Liste des rôles du membre',
@@ -156,14 +156,14 @@ export class MembersController {
     status: HttpStatus.NOT_FOUND,
     description: 'Membre non trouvé',
   })
-  getMemberRoles(@Param('uuid_member') uuid_member: string) {
-    return this.membersService.getMemberRoles(uuid_member);
+  getMemberRoles(@Param('id') idMember: string) {
+    return this.membersService.getMemberRoles(idMember);
   }
 
-  @Put(':uuid_member/assign-role/:uuid_role')
+  @Put(':id/assign-role/:idRole')
   @ApiOperation({ summary: 'Assigner un rôle unique à un membre' })
-  @ApiParam({ name: 'uuid_member', description: 'UUID du membre' })
-  @ApiParam({ name: 'uuid_role', description: 'UUID du rôle à assigner' })
+  @ApiParam({ name: 'idMember', description: 'id du membre' })
+  @ApiParam({ name: 'idRole', description: 'id du rôle à assigner' })
   @ApiResponse({
     status: HttpStatus.OK,
     description: 'Rôle assigné avec succès',
@@ -178,26 +178,26 @@ export class MembersController {
     description: 'Membre ou rôle non trouvé',
   })
   assignRole(
-    @Param('uuid_member') uuid_member: string,
-    @Param('uuid_role') uuid_role: string,
+    @Param('id') idMember: string,
+    @Param('idRole') idRole: string,
   ) {
-    return this.membersService.assignRoleToMember(uuid_member, uuid_role);
+    return this.membersService.assignRoleToMember(idRole, idRole);
   }
 
-  @Delete(':uuid_member/roles/:uuid_role')
+  @Delete(':id/roles/:idRole')
   @ApiOperation({
     summary: "Supprimer un rôle d'un membre",
     description:
       "Supprime un rôle spécifique d'un membre, sans affecter les autres rôles.",
   })
   @ApiParam({
-    name: 'uuid_member',
-    description: 'UUID du membre',
+    name: 'id',
+    description: 'id du membre',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiParam({
-    name: 'uuid_role',
-    description: 'UUID du rôle à supprimer',
+    name: 'idRole',
+    description: 'id du rôle à supprimer',
     example: '172653890987364567',
   })
   @ApiResponse({
@@ -210,21 +210,21 @@ export class MembersController {
     description: 'Membre ou rôle non trouvé.',
   })
   removeRoleFromMember(
-    @Param('uuid_member') uuid_member: string,
-    @Param('uuid_role') uuid_role: string,
+    @Param('id') idMember: string,
+    @Param('idRole') idRole: string,
   ) {
-    return this.membersService.removeRoleFromMember(uuid_member, uuid_role);
+    return this.membersService.removeRoleFromMember(idMember, idRole);
   }
 
-  @Get(':uuid/promotions')
+  @Get(':id/promotions')
   @ApiOperation({
     summary: 'Récupérer les promotions suivies et gérées par un membre',
     description:
-      'Retourne les promotions suivies et gérées par un membre spécifique en utilisant son UUID.',
+      'Retourne les promotions suivies et gérées par un membre spécifique en utilisant son id.',
   })
   @ApiParam({
-    name: 'uuid',
-    description: 'UUID unique du membre à rechercher',
+    name: 'id',
+    description: 'id unique du membre à rechercher',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @ApiResponse({
@@ -233,13 +233,13 @@ export class MembersController {
   })
   @ApiResponse({
     status: HttpStatus.NOT_FOUND,
-    description: "Aucun membre trouvé avec l'UUID fourni.",
+    description: "Aucun membre trouvé avec l'id fourni.",
   })
   @ApiResponse({
     status: HttpStatus.BAD_REQUEST,
     description: "Erreur lors de la récupération des promotions du membre.",
   })
-  findMemberPromotions(@Param('uuid') uuid: string) {
-    return this.membersService.findMemberPromotions(uuid);
+  findMemberPromotions(@Param('id') id: string) {
+    return this.membersService.findMemberPromotions(id);
   }
 }

--- a/src/members/members.service.spec.ts
+++ b/src/members/members.service.spec.ts
@@ -12,7 +12,7 @@ describe('MembersService', () => {
   let rolesRepository: Repository<Role>;
 
   const mockGuild: Guild = {
-    uuid: '123e4567-e89b-12d3-a456-426614174001',
+    idGuild: '123e4567-e89b-12d3-a456-426614174001',
     name: 'Test Guild',
     memberCount: 10,
     configuration: {},
@@ -21,15 +21,15 @@ describe('MembersService', () => {
   };
 
   const mockMember: Member = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174000',
-    guild_username: 'TestUser',
+    idMember: '123e4567-e89b-12d3-a456-426614174000',
+    guildUsername: 'TestUser',
     xp: '100.00',
     level: 1,
-    community_role: 'Member',
+    communityRole: 'Member',
     status: 'Active',
     createdAt: new Date(),
     updatedAt: new Date(),
-    uuidDiscord: '123e4567-e89b-12d3-a456-426614174002',
+    idDiscord: '123e4567-e89b-12d3-a456-426614174002',
     guild: mockGuild,
     roles: []
   };
@@ -60,14 +60,14 @@ describe('MembersService', () => {
   describe('create', () => {
     it('devrait créer un nouveau membre', async () => {
       const createMemberDto = {
-        uuid: '123e4567-e89b-12d3-a456-426614174000',
-        guild_username: 'TestUser',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
+        guildUsername: 'TestUser',
         xp: '100.00',
         level: 1,
-        community_role: 'Member',
+        communityRole: 'Member',
         status: 'Active',
-        uuidGuild: '123e4567-e89b-12d3-a456-426614174001',
-        uuidDiscord: '123e4567-e89b-12d3-a456-426614174002'
+        idGuild: '123e4567-e89b-12d3-a456-426614174001',
+        idDiscord: '123e4567-e89b-12d3-a456-426614174002'
       };
 
       mockMembersRepository.create.mockReturnValue(mockMember);
@@ -96,14 +96,14 @@ describe('MembersService', () => {
   });
 
   describe('findOne', () => {
-    it('devrait retourner un membre par son uuid', async () => {
+    it('devrait retourner un membre par son id', async () => {
       mockMembersRepository.findOne.mockResolvedValue(mockMember);
 
-      const result = await service.findOne(mockMember.uuidMember);
+      const result = await service.findOne(mockMember.idMember);
 
       expect(result).toEqual(mockMember);
       expect(mockMembersRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidMember: mockMember.uuidMember },
+        where: { idMember: mockMember.idMember },
         relations: ['resources']
       });
     });
@@ -111,7 +111,7 @@ describe('MembersService', () => {
     it('devrait lancer une erreur si le membre n\'est pas trouvé', async () => {
       mockMembersRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.findOne('non-existent-uuid'))
+      await expect(service.findOne('non-existent-id'))
         .rejects
         .toThrow(NotFoundException);
     });
@@ -120,7 +120,7 @@ describe('MembersService', () => {
   describe('update', () => {
     it('devrait mettre à jour un membre', async () => {
       const updateMemberDto = {
-        guild_username: 'UpdatedUser',
+        guildUsername: 'UpdatedUser',
         status: 'Inactive'
       };
       const updatedMember = { ...mockMember, ...updateMemberDto };
@@ -128,7 +128,7 @@ describe('MembersService', () => {
       mockMembersRepository.findOne.mockResolvedValue(mockMember);
       mockMembersRepository.save.mockResolvedValue(updatedMember);
 
-      const result = await service.update(mockMember.uuidMember, updateMemberDto);
+      const result = await service.update(mockMember.idMember, updateMemberDto);
 
       expect(result).toEqual(updatedMember);
       expect(mockMembersRepository.save).toHaveBeenCalled();
@@ -137,7 +137,7 @@ describe('MembersService', () => {
     it('devrait lancer une erreur si le membre à mettre à jour n\'existe pas', async () => {
       mockMembersRepository.findOne.mockResolvedValue(null);
 
-      await expect(service.update('non-existent-uuid', {}))
+      await expect(service.update('non-existent-id', {}))
         .rejects
         .toThrow(NotFoundException);
     });
@@ -147,15 +147,15 @@ describe('MembersService', () => {
     it('devrait supprimer un membre', async () => {
       mockMembersRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.remove(mockMember.uuidMember);
+      await service.remove(mockMember.idMember);
 
-      expect(mockMembersRepository.delete).toHaveBeenCalledWith({ uuidMember: mockMember.uuidMember });
+      expect(mockMembersRepository.delete).toHaveBeenCalledWith({ idMember: mockMember.idMember });
     });
 
     it('devrait lancer une erreur si le membre à supprimer n\'existe pas', async () => {
       mockMembersRepository.delete.mockResolvedValue({ affected: 0 });
 
-      await expect(service.remove('non-existent-uuid'))
+      await expect(service.remove('non-existent-id'))
         .rejects
         .toThrow(NotFoundException);
     });

--- a/src/members/members.service.ts
+++ b/src/members/members.service.ts
@@ -29,16 +29,16 @@ export class MembersService {
     });
   }
 
-  // Récupérer un membre par son uuid
-  async findOne(uuidMember: string): Promise<Member> {
+  // Récupérer un membre par son id
+  async findOne(idMember: string): Promise<Member> {
     try {
       const member = await this.membersRepository.findOne({
-        where: { uuidMember },
+        where: { idMember },
         relations: ['resources']
       });
 
       if (!member) {
-        throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+        throw new NotFoundException(`Member with id ${idMember} not found`);
       }
       return member;
     } catch (error) {
@@ -50,15 +50,15 @@ export class MembersService {
   }
 
   // Récupérer les promotions suivies et gérées par un membre
-  async findMemberPromotions(uuidMember: string): Promise<{ followedPromotions: any[], managedPromotions: any[] }> {
+  async findMemberPromotions(idMember: string): Promise<{ followedPromotions: any[], managedPromotions: any[] }> {
     try {
       // Vérifier d'abord si le membre existe
       const member = await this.membersRepository.findOne({
-        where: { uuidMember }
+        where: { idMember }
       });
 
       if (!member) {
-        throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+        throw new NotFoundException(`Member with id ${idMember} not found`);
       }
 
       return {
@@ -74,52 +74,52 @@ export class MembersService {
   }
 
   // Mettre à jour un membre
-  async update(uuidMember: string, updateMemberDto: UpdateMemberDto): Promise<Member> {
-    const member = await this.findOne(uuidMember);
+  async update(idMember: string, updateMemberDto: UpdateMemberDto): Promise<Member> {
+    const member = await this.findOne(idMember);
     Object.assign(member, updateMemberDto);
     return await this.membersRepository.save(member);
   }
 
   // Supprimer un membre
-  async remove(uuidMember: string): Promise<DeleteResult> {
-    const result = await this.membersRepository.delete({ uuidMember });
+  async remove(idMember: string): Promise<DeleteResult> {
+    const result = await this.membersRepository.delete({ idMember });
     if (result.affected === 0) {
-      throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+      throw new NotFoundException(`Member with id ${idMember} not found`);
     }
     return result;
   }
 
-  async getMemberRoles(uuidMember: string): Promise<Role[]> {
+  async getMemberRoles(idMember: string): Promise<Role[]> {
     const member = await this.membersRepository.findOne({
-        where: { uuidMember },
+        where: { idMember },
         relations: ['roles'],
     });
 
     if (!member) {
-        throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+        throw new NotFoundException(`Member with id ${idMember} not found`);
     }
 
     return member.roles;
   }
 
-  async assignRoleToMember(uuidMember: string, uuidRole: string): Promise<Member> {
+  async assignRoleToMember(idMember: string, idRole: string): Promise<Member> {
     const member = await this.membersRepository.findOne({
-        where: { uuidMember },
+        where: { idMember },
         relations: ['roles'],
     });
 
     if (!member) {
-        throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+        throw new NotFoundException(`Member with id ${idMember} not found`);
     }
 
-    const role = await this.rolesRepository.findOne({ where: { uuidRole } });
+    const role = await this.rolesRepository.findOne({ where: { idRole } });
     if (!role) {
-        throw new NotFoundException(`Role with UUID ${uuidRole} not found`);
+        throw new NotFoundException(`Role with id ${idRole} not found`);
     }
 
     // Vérifier si le membre possède déjà ce rôle
-    if (member.roles.some(r => r.uuidRole === uuidRole)) {
-        throw new BadRequestException(`Member already has the role ${uuidRole}`);
+    if (member.roles.some(r => r.idRole === idRole)) {
+        throw new BadRequestException(`Member already has the role ${idRole}`);
     }
 
     // Ajouter le rôle au membre
@@ -132,23 +132,23 @@ export class MembersService {
     return await this.membersRepository.save(member);
   }
 
-  async removeRoleFromMember(uuidMember: string, uuidRole: string): Promise<Member> {
+  async removeRoleFromMember(idMember: string, idRole: string): Promise<Member> {
     const member = await this.membersRepository.findOne({
-        where: { uuidMember },
+        where: { idMember },
         relations: ['roles'],
     });
 
     if (!member) {
-        throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+        throw new NotFoundException(`Member with id ${idMember} not found`);
     }
 
-    const role = await this.rolesRepository.findOne({ where: { uuidRole } });
+    const role = await this.rolesRepository.findOne({ where: { idRole } });
     if (!role) {
-        throw new NotFoundException(`Role with UUID ${uuidRole} not found`);
+        throw new NotFoundException(`Role with id ${idRole} not found`);
     }
 
     // Supprimer le rôle du membre
-    member.roles = member.roles.filter(r => r.uuidRole !== uuidRole);
+    member.roles = member.roles.filter(r => r.idRole !== idRole);
 
     // Mettre à jour `member_count`
     role.memberCount = Math.max(0, parseInt(role.memberCount.toString(), 10) - 1);

--- a/src/moderator-actions/dto/create-moderator-action.dto.ts
+++ b/src/moderator-actions/dto/create-moderator-action.dto.ts
@@ -1,16 +1,16 @@
 import { IsString, IsNotEmpty, IsEnum, Length } from 'class-validator';
 import { Transform } from 'class-transformer';
 import { ApiProperty, PickType } from '@nestjs/swagger';
-import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from '../../utils/pickable-intern-id-fields';
 
 export enum ActionType {
   BAN = 'ban',
   WARN = 'warn'
 }
 
-export class CreateModeratorActionDto extends PickType(PickableInternUUIDFields, [
-  'uuidMember', // Pour le modérateur
-  'uuidReport' // Pour le signalement
+export class CreateModeratorActionDto extends PickType(PickableInternIdFields, [
+  'idMember', // Pour le modérateur
+  'idReport' // Pour le signalement
 ]) {
   @ApiProperty({
     description: 'Type d\'action',

--- a/src/moderator-actions/entities/moderator-action.entity.ts
+++ b/src/moderator-actions/entities/moderator-action.entity.ts
@@ -16,11 +16,11 @@ export enum ActionType {
 @Entity('moderator_actions')
 export class ModeratorAction {
   @ApiProperty({
-    description: 'UUID unique de l\'action de modération',
+    description: 'id unique de l\'action de modération',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_moderation' })
-  uuidModeration: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_moderation' })
+  idModeration: string;
 
   @ApiProperty({
     description: 'Type d\'action prise',
@@ -50,49 +50,49 @@ export class ModeratorAction {
 
   // Relation avec le modérateur
   @ManyToOne(() => Member)
-  @JoinColumn({ name: 'moderator_uuid' })
+  @JoinColumn({ name: 'id_moderator' })
   moderator: Member;
 
   @ApiProperty({
-    description: 'UUID du modérateur',
+    description: 'id du modérateur',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ type: 'uuid', name: 'moderator_uuid' })
-  moderatorUuid: string;
+  @Column({ type: 'uuid', name: 'id_moderator' })
+  idModerator: string;
 
   // Relation avec le signalement
   @ManyToOne(() => Report)
-  @JoinColumn({ name: 'report_uuid' })
+  @JoinColumn({ name: 'id_report' })
   report: Report;
 
   @ApiProperty({
-    description: 'UUID du signalement',
+    description: 'id du signalement',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ type: 'uuid', name: 'report_uuid' })
-  reportUuid: string;
+  @Column({ type: 'uuid', name: 'id_report' })
+  idReport: string;
 
   // Relations avec les cibles possibles
   @ManyToOne(() => Resource, { nullable: true })
-  @JoinColumn({ name: 'resource_uuid' })
+  @JoinColumn({ name: 'id_resource' })
   resource?: Resource;
 
-  @Column({ type: 'uuid', name: 'resource_uuid', nullable: true })
-  resourceUuid?: string;
+  @Column({ type: 'uuid', name: 'id_resource', nullable: true })
+  idResource?: string;
 
   @ManyToOne(() => Member, { nullable: true })
-  @JoinColumn({ name: 'target_member_uuid' })
+  @JoinColumn({ name: 'id_target_member' })
   targetMember?: Member;
 
-  @Column({ type: 'uuid', name: 'target_member_uuid', nullable: true })
-  targetMemberUuid?: string;
+  @Column({ type: 'uuid', name: 'id_target_member', nullable: true })
+  idTargetMember?: string;
 
   @ManyToOne(() => Comment, { nullable: true })
-  @JoinColumn({ name: 'comment_uuid' })
+  @JoinColumn({ name: 'id_comment' })
   comment?: Comment;
 
-  @Column({ type: 'uuid', name: 'comment_uuid', nullable: true })
-  commentUuid?: string;
+  @Column({ type: 'uuid', name: 'id_comment', nullable: true })
+  idComment?: string;
 
   @ApiProperty({
     description: 'Date de dernière modification de l\'action',

--- a/src/moderator-actions/moderator-actions.controller.spec.ts
+++ b/src/moderator-actions/moderator-actions.controller.spec.ts
@@ -11,18 +11,18 @@ describe('ModeratorActionsController', () => {
   let service: ModeratorActionsService;
 
   const mockModeratorAction: ModeratorAction = {
-    uuidModeration: '123e4567-e89b-12d3-a456-426614174000',
+    idModeration: '123e4567-e89b-12d3-a456-426614174000',
     actionType: 'warning',
     actionReason: 'Test reason',
     actionCreatedAt: new Date(),
-    moderatorUuid: '123e4567-e89b-12d3-a456-426614174001',
-    reportUuid: '123e4567-e89b-12d3-a456-426614174002',
+    idModerator: '123e4567-e89b-12d3-a456-426614174001',
+    idReport: '123e4567-e89b-12d3-a456-426614174002',
     updatedAt: new Date(),
   } as ModeratorAction;
 
   const mockCreateDto: CreateModeratorActionDto = {
-    uuidMember: mockModeratorAction.moderatorUuid,
-    uuidReport: mockModeratorAction.reportUuid,
+    idMember: mockModeratorAction.idModerator,
+    idReport: mockModeratorAction.idReport,
     type: ActionType.WARN,
     reason: mockModeratorAction.actionReason,
   };
@@ -50,12 +50,12 @@ describe('ModeratorActionsController', () => {
 
   describe('create', () => {
     it('devrait créer une nouvelle action de modération', async () => {
-      const result = await controller.create(mockCreateDto, mockModeratorAction.moderatorUuid);
+      const result = await controller.create(mockCreateDto, mockModeratorAction.idModerator);
       expect(result).toEqual(mockModeratorAction);
       expect(service.create).toHaveBeenCalledWith(mockCreateDto);
     });
 
-    it('devrait lever une exception si l\'UUID du membre ne correspond pas', async () => {
+    it('devrait lever une exception si l\'id du membre ne correspond pas', async () => {
       await expect(
         controller.create(mockCreateDto, 'different-uuid')
       ).rejects.toThrow(UnauthorizedException);
@@ -72,9 +72,9 @@ describe('ModeratorActionsController', () => {
 
   describe('findOne', () => {
     it('devrait retourner une action de modération spécifique', async () => {
-      const result = await controller.findOne(mockModeratorAction.uuidModeration);
+      const result = await controller.findOne(mockModeratorAction.idModeration);
       expect(result).toEqual(mockModeratorAction);
-      expect(service.findOne).toHaveBeenCalledWith(mockModeratorAction.uuidModeration);
+      expect(service.findOne).toHaveBeenCalledWith(mockModeratorAction.idModeration);
     });
 
     it('devrait gérer les actions non trouvées', async () => {
@@ -87,16 +87,16 @@ describe('ModeratorActionsController', () => {
 
   describe('remove', () => {
     it('devrait supprimer une action de modération', async () => {
-      await controller.remove(mockModeratorAction.uuidModeration);
-      expect(service.remove).toHaveBeenCalledWith(mockModeratorAction.uuidModeration);
+      await controller.remove(mockModeratorAction.idModeration);
+      expect(service.remove).toHaveBeenCalledWith(mockModeratorAction.idModeration);
     });
   });
 
   describe('findByReport', () => {
     it('devrait retourner les actions de modération pour un signalement', async () => {
-      const result = await controller.findByReport(mockModeratorAction.reportUuid);
+      const result = await controller.findByReport(mockModeratorAction.idReport);
       expect(result).toEqual([mockModeratorAction]);
-      expect(service.findByReport).toHaveBeenCalledWith(mockModeratorAction.reportUuid);
+      expect(service.findByReport).toHaveBeenCalledWith(mockModeratorAction.idReport);
     });
 
     it('devrait gérer les signalements non trouvés', async () => {

--- a/src/moderator-actions/moderator-actions.controller.ts
+++ b/src/moderator-actions/moderator-actions.controller.ts
@@ -34,8 +34,8 @@ export class ModeratorActionsController {
     description: 'Permet à un modérateur de prendre une action suite à un signalement'
   })
   @ApiHeader({
-    name: 'X-Member-UUID',
-    description: 'UUID du modérateur',
+    name: 'X-Member-id',
+    description: 'id du modérateur',
     required: true
   })
   @ApiBody({ type: CreateModeratorActionDto })
@@ -50,9 +50,9 @@ export class ModeratorActionsController {
   async create(
     @Body(new ValidationPipe({ transform: true }))
     createDto: CreateModeratorActionDto,
-    @Headers('X-Member-UUID') currentUserId: string
+    @Headers('X-Member-id') currentUserId: string
   ): Promise<ModeratorAction> {
-    if (currentUserId !== createDto.uuidMember) {
+    if (currentUserId !== createDto.idMember) {
       throw new UnauthorizedException('Vous n\'êtes pas autorisé à effectuer cette action');
     }
 
@@ -80,18 +80,18 @@ export class ModeratorActionsController {
 
   /**
    * Récupère une action de modération spécifique
-   * @param uuid UUID de l'action à récupérer
+   * @param id UUID de l'action à récupérer
    * @returns L'action trouvée avec un statut 200
    */
-  @Get(':uuid')
+  @Get(':id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ 
-    summary: 'Récupérer une action de modération par son UUID',
+    summary: 'Récupérer une action de modération par son id',
     description: 'Retourne les détails d\'une action de modération spécifique.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID de l\'action de modération',
+    name: 'id',
+    description: 'id de l\'action de modération',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -100,39 +100,39 @@ export class ModeratorActionsController {
     type: ModeratorAction 
   })
   @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Action de modération non trouvée' })
-  async findOne(@Param('uuid') uuid: string): Promise<ModeratorAction> {
-    return this.moderatorActionsService.findOne(uuid);
+  async findOne(@Param('id') id: string): Promise<ModeratorAction> {
+    return this.moderatorActionsService.findOne(id);
   }
 
   /**
    * Supprime une action de modération
-   * @param uuid UUID de l'action à supprimer
+   * @param id id de l'action à supprimer
    * @returns Message de confirmation avec un statut 200
    */
-  @Delete(':uuid')
+  @Delete(':id')
   @HttpCode(HttpStatus.OK)
   @ApiOperation({ 
     summary: 'Supprimer une action de modération',
     description: 'Les actions de modération ne peuvent pas être supprimées.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID de l\'action de modération',
+    name: 'id',
+    description: 'id de l\'action de modération',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ status: HttpStatus.BAD_REQUEST, description: 'Opération non autorisée' })
-  async remove(@Param('uuid') uuid: string): Promise<void> {
-    await this.moderatorActionsService.remove(uuid);
+  async remove(@Param('id') id: string): Promise<void> {
+    await this.moderatorActionsService.remove(id);
   }
 
-  @Get('report/:reportUuid')
+  @Get('report/:idReport')
   @ApiOperation({ 
     summary: 'Récupérer les actions de modération pour un signalement',
     description: 'Retourne la liste des actions de modération liées à un signalement spécifique.'
   })
   @ApiParam({ 
-    name: 'reportUuid',
-    description: 'UUID du signalement',
+    name: 'idReport',
+    description: 'id du signalement',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -141,7 +141,7 @@ export class ModeratorActionsController {
     type: [ModeratorAction] 
   })
   @ApiResponse({ status: HttpStatus.NOT_FOUND, description: 'Signalement non trouvé' })
-  async findByReport(@Param('reportUuid') reportUuid: string): Promise<ModeratorAction[]> {
-    return this.moderatorActionsService.findByReport(reportUuid);
+  async findByReport(@Param('idReport') idReport: string): Promise<ModeratorAction[]> {
+    return this.moderatorActionsService.findByReport(idReport);
   }
 }

--- a/src/moderator-actions/moderator-actions.service.spec.ts
+++ b/src/moderator-actions/moderator-actions.service.spec.ts
@@ -16,27 +16,27 @@ describe('ModeratorActionsService', () => {
   let memberRepository: Repository<Member>;
 
   const mockModeratorAction = {
-    uuidModeration: '123e4567-e89b-12d3-a456-426614174000',
+    idModeration: '123e4567-e89b-12d3-a456-426614174000',
     actionType: 'warning',
     actionReason: 'Test reason',
-    moderatorUuid: '123e4567-e89b-12d3-a456-426614174001',
-    reportUuid: '123e4567-e89b-12d3-a456-426614174002',
+    idModerator: '123e4567-e89b-12d3-a456-426614174001',
+    idReport: '123e4567-e89b-12d3-a456-426614174002',
   };
 
   const mockReport = {
-    uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+    idReport: '123e4567-e89b-12d3-a456-426614174002',
     status: 'pending',
     save: vi.fn(),
   };
 
   const mockModerator: Partial<Member> = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+    idMember: '123e4567-e89b-12d3-a456-426614174001',
     communityRole: 'Moderator',
   };
 
   const mockCreateDto: CreateModeratorActionDto = {
-    uuidMember: mockModerator.uuidMember!,
-    uuidReport: mockReport.uuidReport,
+    idMember: mockModerator.idMember!,
+    idReport: mockReport.idReport,
     type: ActionType.WARN,
     reason: 'Test reason',
   };
@@ -121,7 +121,7 @@ describe('ModeratorActionsService', () => {
 
   describe('findOne', () => {
     it('devrait retourner une action de modération spécifique', async () => {
-      const result = await service.findOne(mockModeratorAction.uuidModeration);
+      const result = await service.findOne(mockModeratorAction.idModeration);
       expect(result).toEqual(mockModeratorAction);
     });
 
@@ -133,19 +133,19 @@ describe('ModeratorActionsService', () => {
 
   describe('findByReport', () => {
     it('devrait retourner les actions de modération pour un signalement', async () => {
-      const result = await service.findByReport(mockReport.uuidReport);
+      const result = await service.findByReport(mockReport.idReport);
       expect(result).toEqual([mockModeratorAction]);
     });
 
     it('devrait gérer les erreurs de base de données', async () => {
       vi.spyOn(moderatorActionRepository, 'find').mockRejectedValueOnce(new Error());
-      await expect(service.findByReport(mockReport.uuidReport)).rejects.toThrow(BadRequestException);
+      await expect(service.findByReport(mockReport.idReport)).rejects.toThrow(BadRequestException);
     });
   });
 
   describe('remove', () => {
     it('devrait lever une exception car la suppression n\'est pas autorisée', async () => {
-      await expect(service.remove(mockModeratorAction.uuidModeration)).rejects.toThrow(BadRequestException);
+      await expect(service.remove(mockModeratorAction.idModeration)).rejects.toThrow(BadRequestException);
     });
   });
 }); 

--- a/src/moderator-actions/moderator-actions.service.ts
+++ b/src/moderator-actions/moderator-actions.service.ts
@@ -26,11 +26,11 @@ export class ModeratorActionsService {
   async create(createDto: CreateModeratorActionDto): Promise<ModeratorAction> {
     // Vérifier que le membre existe et est modérateur
     const member = await this.memberRepository.findOne({
-      where: { uuidMember: createDto.uuidMember }
+      where: { idMember: createDto.idMember }
     });
 
     if (!member) {
-      throw new NotFoundException(`Member with UUID ${createDto.uuidMember} not found`);
+      throw new NotFoundException(`Member with id ${createDto.idMember} not found`);
     }
 
     // Vérifier que le membre est modérateur
@@ -40,11 +40,11 @@ export class ModeratorActionsService {
 
     // Vérifier que le signalement existe
     const report = await this.reportRepository.findOne({
-      where: { uuidReport: createDto.uuidReport }
+      where: { idReport: createDto.idReport }
     });
 
     if (!report) {
-      throw new NotFoundException(`Report with UUID ${createDto.uuidReport} not found`);
+      throw new NotFoundException(`Report with id ${createDto.idReport} not found`);
     }
 
     try {
@@ -65,9 +65,9 @@ export class ModeratorActionsService {
         actionType,
         actionReason: createDto.reason,
         moderator: member,
-        moderatorUuid: member.uuidMember,
+        idModerator: member.idMember,
         report,
-        reportUuid: report.uuidReport
+        idReport: report.idReport
       });
 
       const savedAction = await this.moderatorActionRepository.save(moderatorAction);
@@ -107,16 +107,16 @@ export class ModeratorActionsService {
    * Récupère une action de modération spécifique
    * @throws NotFoundException si l'action n'existe pas
    */
-  async findOne(uuid: string): Promise<ModeratorAction> {
+  async findOne(idModeration: string): Promise<ModeratorAction> {
     try {
       const action = await this.moderatorActionRepository.findOne({
-        where: { uuidModeration: uuid },
+        where: { idModeration: idModeration },
         relations: ['moderator', 'report']
       });
 
       if (!action) {
         throw new NotFoundException(
-          `Action de modération avec l'UUID ${uuid} non trouvée`,
+          `Action de modération avec l'id ${idModeration} non trouvée`,
         );
       }
 
@@ -131,10 +131,10 @@ export class ModeratorActionsService {
     }
   }
 
-  async findByReport(reportUuid: string): Promise<ModeratorAction[]> {
+  async findByReport(idReport: string): Promise<ModeratorAction[]> {
     try {
       return await this.moderatorActionRepository.find({
-        where: { reportUuid },
+        where: { idReport },
         relations: ['moderator', 'report'],
         order: {
           actionCreatedAt: 'DESC'
@@ -151,7 +151,7 @@ export class ModeratorActionsService {
    * Supprime une action de modération
    * @throws NotFoundException si l'action n'existe pas
    */
-  async remove(uuid: string): Promise<void> {
+  async remove(idModeration: string): Promise<void> {
     throw new BadRequestException('Les actions de modération ne peuvent pas être supprimées');
   }
 }

--- a/src/poll-templates/entities/poll-template.entity.ts
+++ b/src/poll-templates/entities/poll-template.entity.ts
@@ -5,12 +5,12 @@ import { QuestionTemplate } from 'src/question-templates/entities/question-templ
 
 @Entity('poll-templates')
 export class PollTemplate {
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_poll_template' })
+  @PrimaryGeneratedColumn('uuid', { name: 'id_poll_template' })
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-446655440000',
     description: "The unique identifier of the poll template"
   })
-  uuid: string;
+  idPollTemplate: string;
 
   @Column({ type: 'varchar', length: 50 })
   @ApiProperty({

--- a/src/poll-templates/poll-templates.controller.ts
+++ b/src/poll-templates/poll-templates.controller.ts
@@ -24,27 +24,27 @@ export class PollTemplatesController {
     return this.pollTemplatesService.findAll();
   }
 
-  @Get(':uuid')
+  @Get(':id')
   @ApiOperation({ summary: 'Retrieve a specific poll template by ID' })
   @ApiResponse({ status: 200, description: 'The poll template was retrieved successfully.' })
   @ApiResponse({ status: 404, description: 'Poll template not found.' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.pollTemplatesService.findOne(uuid);
+  findOne(@Param('id') id: string) {
+    return this.pollTemplatesService.findOne(id);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Update a specific poll template by ID' })
   @ApiResponse({ status: 200, description: 'The poll template was updated successfully.' })
   @ApiResponse({ status: 404, description: 'Poll template not found.' })
-  update(@Param('uuid') uuid: string, @Body() updatePollTemplateDto: UpdatePollTemplateDto) {
-    return this.pollTemplatesService.update(uuid, updatePollTemplateDto);
+  update(@Param('id') id: string, @Body() updatePollTemplateDto: UpdatePollTemplateDto) {
+    return this.pollTemplatesService.update(id, updatePollTemplateDto);
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Delete a specific poll template by ID' })
   @ApiResponse({ status: 200, description: 'The poll template was deleted successfully.' })
   @ApiResponse({ status: 404, description: 'Poll template not found.' })
-  remove(@Param('uuid') uuid: string) {
-    return this.pollTemplatesService.remove(uuid);
+  remove(@Param('id') id: string) {
+    return this.pollTemplatesService.remove(id);
   }
 }

--- a/src/poll-templates/poll-templates.service.ts
+++ b/src/poll-templates/poll-templates.service.ts
@@ -22,39 +22,39 @@ export class PollTemplatesService {
     return this.pollTemplateRepository.find();
   }
 
-  async findOne(uuid: string): Promise<PollTemplate> {
-    if (!isUUID(uuid)) {
-      throw new NotFoundException(`The poll template with UUID ${uuid} does not exist`);
+  async findOne(idPollTemplate: string): Promise<PollTemplate> {
+    if (!isUUID(idPollTemplate)) {
+      throw new NotFoundException(`The poll template with id ${idPollTemplate} does not exist`);
     }
-    const pollTemplate = await this.pollTemplateRepository.findOne({ where: { uuid } });
+    const pollTemplate = await this.pollTemplateRepository.findOne({ where: { idPollTemplate: idPollTemplate } });
     if (!pollTemplate) {
-      throw new NotFoundException(`The poll template with UUID ${uuid} does not exist`);
+      throw new NotFoundException(`The poll template with id ${idPollTemplate} does not exist`);
     }
     return pollTemplate;
   }
 
-  async update(uuid: string, updatePollTemplateDto: UpdatePollTemplateDto) : Promise<PollTemplate> {
-    if (!isUUID(uuid)) {
-      throw new NotFoundException(`The poll template with UUID ${uuid} does not exist`);
+  async update(idPollTemplate: string, updatePollTemplateDto: UpdatePollTemplateDto) : Promise<PollTemplate> {
+    if (!isUUID(idPollTemplate)) {
+      throw new NotFoundException(`The poll template with id ${idPollTemplate} does not exist`);
     }
     const pollTemplate = await this.pollTemplateRepository.preload({
-      uuid,
+      idPollTemplate,
       ...updatePollTemplateDto
     })
     if (!pollTemplate) {
-      throw new NotFoundException(`The poll template with UUID ${uuid} does not exist`);
+      throw new NotFoundException(`The poll template with id ${idPollTemplate} does not exist`);
     }
     return this.pollTemplateRepository.save(pollTemplate); 
   }
 
-  async remove(uuid: string) : Promise<DeleteResult> {
-    if (!isUUID(uuid)) {
-      throw new NotFoundException(`The poll template with UUID ${uuid} does not exist`);
+  async remove(idPollTemplate: string) : Promise<DeleteResult> {
+    if (!isUUID(idPollTemplate)) {
+      throw new NotFoundException(`The poll template with id ${idPollTemplate} does not exist`);
     }
-    const pollTemplate = await this.pollTemplateRepository.findOne({ where: { uuid } });
+    const pollTemplate = await this.pollTemplateRepository.findOne({ where: { idPollTemplate } });
     if (!pollTemplate) {
-      throw new NotFoundException(`The poll template with UUID ${uuid} does not exist`);
+      throw new NotFoundException(`The poll template with id ${idPollTemplate} does not exist`);
     }
-    return await this.pollTemplateRepository.delete(uuid);
+    return await this.pollTemplateRepository.delete(idPollTemplate);
   }
 }

--- a/src/polls/dto/create-poll.dto.ts
+++ b/src/polls/dto/create-poll.dto.ts
@@ -2,9 +2,9 @@ import { IsString, IsNotEmpty, IsBoolean, IsInt, MaxLength, Length, ArrayMinSize
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { CreateQuestionDto } from 'src/questions/dto/create-question.dto';
 import { Type } from 'class-transformer';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 
-export class CreatePollDto extends PickType(PickableInternUUIDFields, ['uuidMember']) {
+export class CreatePollDto extends PickType(PickableInternIdFields, ['idMember']) {
   @ApiProperty({ 
     description: "The title of the poll, which should be concise and descriptive.", 
     maxLength: 50, 
@@ -21,10 +21,10 @@ export class CreatePollDto extends PickType(PickableInternUUIDFields, ['uuidMemb
     maxLength: 19, 
     example: '1234567890123456789' 
   })
-  @IsString({message: "The message UUID must be a string"})
-  @IsNotEmpty({message: "The message UUID is required"})
-  @Length(17,19, {message: "The message UUID must be a string of 17 to 19 characters"})
-  uuidMessage: string;
+  @IsString({message: "The message id must be a string"})
+  @IsNotEmpty({message: "The message id is required"})
+  @Length(17,19, {message: "The message id must be a string of 17 to 19 characters"})
+  idMessage: string;
 
   @ApiProperty({ 
     description: "Indicate if the responses to this poll are anonymous.", 

--- a/src/polls/dto/update-poll.dto.ts
+++ b/src/polls/dto/update-poll.dto.ts
@@ -1,4 +1,4 @@
 import { OmitType } from '@nestjs/swagger';
 import { CreatePollDto } from './create-poll.dto';
 
-export class UpdatePollDto extends OmitType(CreatePollDto, ['uuidMessage']) {}
+export class UpdatePollDto extends OmitType(CreatePollDto, ['idMessage']) {}

--- a/src/polls/entities/poll.entity.ts
+++ b/src/polls/entities/poll.entity.ts
@@ -5,12 +5,12 @@ import { Member } from 'src/members/entities/member.entity';
 
 @Entity('polls')
 export class Poll {
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_poll' })
+  @PrimaryGeneratedColumn('uuid', { name: 'id_poll' })
   @ApiProperty({
     example: '550e8400-e29b-41d4-a716-446655440000',
     description: "The unique identifier of the poll"
   })
-  uuid: string;
+  idPoll: string;
 
   @Column({ type: 'varchar', length: 50 })
   @ApiProperty({
@@ -20,13 +20,13 @@ export class Poll {
   })
   title: string;
 
-  @Column({ type: 'varchar', length: 19, name: 'uuid_message' })
+  @Column({ type: 'varchar', length: 19, name: 'id_message' })
   @ApiProperty({
     maxLength: 19,
     example: '1234567890123456789',
     description: "The ID of the associated message, used to link the poll to a specific message."
   })
-  uuidMessage: string;
+  idMessage: string;
 
   @Column({ type: 'boolean', name: 'is_anonymous' })
   @ApiProperty({
@@ -71,7 +71,7 @@ export class Poll {
   //     type: () => Member
   // })
   @ManyToOne(() => Member, (author) => author.polls, {nullable: false})
-  @JoinColumn({ name: 'uuid_author' })
+  @JoinColumn({ name: 'id_author' })
   author: Member;
 
   @CreateDateColumn({

--- a/src/polls/polls.controller.spec.ts
+++ b/src/polls/polls.controller.spec.ts
@@ -44,11 +44,11 @@ describe('PollsController', () => {
   describe('create', () => {
     const createPollDto: CreatePollDto = {
       title: 'Test Poll',
-      uuidMessage: '12345678901234567',
+      idMessage: '12345678901234567',
       isAnonymous: false,
       isClosed: false,
       duration: 24,
-      uuidMember: '550e8400-e29b-41d4-a716-446655440000',
+      idMember: '550e8400-e29b-41d4-a716-446655440000',
       questions: [
         {
           content: 'Test Question',
@@ -63,7 +63,7 @@ describe('PollsController', () => {
 
     it('should create a new poll', async () => {
       const expectedResult = {
-        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        idPoll: '550e8400-e29b-41d4-a716-446655440000',
         ...createPollDto,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -82,9 +82,9 @@ describe('PollsController', () => {
     it('should return an array of polls', async () => {
       const expectedResult = [
         {
-          uuid: '550e8400-e29b-41d4-a716-446655440000',
+          idPoll: '550e8400-e29b-41d4-a716-446655440000',
           title: 'Poll 1',
-          uuidMessage: '12345678901234567',
+          idMessage: '12345678901234567',
           isTemplate: false,
           isAnonymous: false,
           isClosed: false,
@@ -114,13 +114,13 @@ describe('PollsController', () => {
   });
 
   describe('findOne', () => {
-    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const idPoll = '550e8400-e29b-41d4-a716-446655440000';
 
     it('should return a single poll', async () => {
       const expectedResult = {
-        uuid,
+        idPoll,
         title: 'Test Poll',
-        uuidMessage: '12345678901234567',
+        idMessage: '12345678901234567',
         isTemplate: false,
         isAnonymous: false,
         isClosed: false,
@@ -141,28 +141,28 @@ describe('PollsController', () => {
 
       mockPollsService.findOne.mockResolvedValue(expectedResult);
 
-      const result = await controller.findOne(uuid);
+      const result = await controller.findOne(idPoll);
 
       expect(result).toEqual(expectedResult);
-      expect(mockPollsService.findOne).toHaveBeenCalledWith(uuid);
+      expect(mockPollsService.findOne).toHaveBeenCalledWith(idPoll);
     });
 
     it('should throw NotFoundException when poll is not found', async () => {
       mockPollsService.findOne.mockRejectedValue(new NotFoundException());
 
-      await expect(controller.findOne(uuid)).rejects.toThrow(NotFoundException);
-      expect(mockPollsService.findOne).toHaveBeenCalledWith(uuid);
+      await expect(controller.findOne(idPoll)).rejects.toThrow(NotFoundException);
+      expect(mockPollsService.findOne).toHaveBeenCalledWith(idPoll);
     });
   });
 
   describe('update', () => {
-    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const idPoll = '550e8400-e29b-41d4-a716-446655440000';
     const updatePollDto: UpdatePollDto = {
       title: 'Updated Poll',
       isAnonymous: true,
       isClosed: false,
       duration: 48,
-      uuidMember: '550e8400-e29b-41d4-a716-446655440000',
+      idMember: '550e8400-e29b-41d4-a716-446655440000',
       questions: [
         {
           content: 'Updated Question',
@@ -177,50 +177,50 @@ describe('PollsController', () => {
 
     it('should update a poll', async () => {
       const expectedResult = {
-        uuid,
+        idPoll,
         ...updatePollDto,
-        uuidMessage: '12345678901234567',
+        idMessage: '12345678901234567',
         createdAt: new Date(),
         updatedAt: new Date(),
       };
 
       mockPollsService.update.mockResolvedValue(expectedResult);
 
-      const result = await controller.update(uuid, updatePollDto);
+      const result = await controller.update(idPoll, updatePollDto);
 
       expect(result).toEqual(expectedResult);
-      expect(mockPollsService.update).toHaveBeenCalledWith(uuid, updatePollDto);
+      expect(mockPollsService.update).toHaveBeenCalledWith(idPoll, updatePollDto);
     });
 
     it('should throw NotFoundException when poll to update is not found', async () => {
       mockPollsService.update.mockRejectedValue(new NotFoundException());
 
-      await expect(controller.update(uuid, updatePollDto)).rejects.toThrow(
+      await expect(controller.update(idPoll, updatePollDto)).rejects.toThrow(
         NotFoundException,
       );
-      expect(mockPollsService.update).toHaveBeenCalledWith(uuid, updatePollDto);
+      expect(mockPollsService.update).toHaveBeenCalledWith(idPoll, updatePollDto);
     });
   });
 
   describe('remove', () => {
-    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const idPoll = '550e8400-e29b-41d4-a716-446655440000';
 
     it('should delete a poll', async () => {
       const expectedResult = { affected: 1, raw: [] };
 
       mockPollsService.remove.mockResolvedValue(expectedResult);
 
-      const result = await controller.remove(uuid);
+      const result = await controller.remove(idPoll);
 
       expect(result).toEqual(expectedResult);
-      expect(mockPollsService.remove).toHaveBeenCalledWith(uuid);
+      expect(mockPollsService.remove).toHaveBeenCalledWith(idPoll);
     });
 
     it('should throw NotFoundException when poll to delete is not found', async () => {
       mockPollsService.remove.mockRejectedValue(new NotFoundException());
 
-      await expect(controller.remove(uuid)).rejects.toThrow(NotFoundException);
-      expect(mockPollsService.remove).toHaveBeenCalledWith(uuid);
+      await expect(controller.remove(idPoll)).rejects.toThrow(NotFoundException);
+      expect(mockPollsService.remove).toHaveBeenCalledWith(idPoll);
     });
   });
 });

--- a/src/polls/polls.controller.ts
+++ b/src/polls/polls.controller.ts
@@ -29,23 +29,23 @@ export class PollsController {
   @ApiOperation({ summary: 'Retrieve a specific poll by ID' })
   @ApiResponse({ status: 200, description: 'The poll was retrieved successfully.', type: Poll })
   @ApiResponse({ status: 404, description: 'Poll not found.' })
-  findOne(@Param('id') id: string): Promise<Poll | null> {
-    return this.pollsService.findOne(id);
+  findOne(@Param('id') idPoll: string): Promise<Poll | null> {
+    return this.pollsService.findOne(idPoll);
   }
 
   @Put(':id')
   @ApiOperation({ summary: 'Update a specific poll by ID' })
   @ApiResponse({ status: 200, description: 'The poll was updated successfully.', type: Poll })
   @ApiResponse({ status: 404, description: 'Poll not found.' })
-  update(@Param('id') id: string, @Body() updatePollDto: UpdatePollDto): Promise<Poll | null> {
-    return this.pollsService.update(id, updatePollDto);
+  update(@Param('id') idPoll: string, @Body() updatePollDto: UpdatePollDto): Promise<Poll | null> {
+    return this.pollsService.update(idPoll, updatePollDto);
   }
 
   @Delete(':id')
   @ApiOperation({ summary: 'Delete a specific poll by ID' })
   @ApiResponse({ status: 200, description: 'The poll was deleted successfully.', type: DeleteResult })
   @ApiResponse({ status: 404, description: 'Poll not found.' })
-  remove(@Param('id') id: string): Promise<DeleteResult> {
-    return this.pollsService.remove(id);
+  remove(@Param('id') idPoll: string): Promise<DeleteResult> {
+    return this.pollsService.remove(idPoll);
   }
 }

--- a/src/polls/polls.integration.spec.ts
+++ b/src/polls/polls.integration.spec.ts
@@ -162,7 +162,7 @@ describe('Polls Integration Tests', () => {
   //     const uuid = createResponse.body.uuid;
 
   //     return request(app.getHttpServer())
-  //       .get(`/polls/${uuid}`)
+  //       .get(`/polls/${id}`)
   //       .expect(200)
   //       .then((response) => {
   //         expect(response.body.uuid).toBe(uuid);
@@ -210,7 +210,7 @@ describe('Polls Integration Tests', () => {
   //     };
 
   //     return request(app.getHttpServer())
-  //       .put(`/polls/${uuid}`)
+  //       .put(`/polls/${id}`)
   //       .send(updateData)
   //       .expect(200)
   //       .then((response) => {
@@ -244,12 +244,12 @@ describe('Polls Integration Tests', () => {
 
   //     // Delete the poll
   //     await request(app.getHttpServer())
-  //       .delete(`/polls/${uuid}`)
+  //       .delete(`/polls/${id}`)
   //       .expect(200);
 
   //     // Verify the poll is deleted
   //     return request(app.getHttpServer())
-  //       .get(`/polls/${uuid}`)
+  //       .get(`/polls/${id}`)
   //       .expect(404);
   //   });
 

--- a/src/polls/polls.service.spec.ts
+++ b/src/polls/polls.service.spec.ts
@@ -46,7 +46,7 @@ describe('PollsService', () => {
   describe('create', () => {
     const createPollDto: CreatePollDto = {
       title: 'Test Poll',
-      uuidMessage: '12345678901234567',
+      idMessage: '12345678901234567',
       isAnonymous: false,
       isClosed: false,
       duration: 24,
@@ -64,7 +64,7 @@ describe('PollsService', () => {
 
     it('should successfully create a poll', async () => {
       const expectedPoll = {
-        uuid: '550e8400-e29b-41d4-a716-446655440000',
+        idPoll: '550e8400-e29b-41d4-a716-446655440000',
         ...createPollDto,
         createdAt: new Date(),
         updatedAt: new Date(),
@@ -85,9 +85,9 @@ describe('PollsService', () => {
     it('should return an array of polls', async () => {
       const expectedPolls = [
         {
-          uuid: '550e8400-e29b-41d4-a716-446655440000',
+          idPoll: '550e8400-e29b-41d4-a716-446655440000',
           title: 'Test Poll 1',
-          uuidMessage: '12345678901234567',
+          idMessage: '12345678901234567',
           isTemplate: false,
           isAnonymous: false,
           isClosed: false,
@@ -117,13 +117,13 @@ describe('PollsService', () => {
   });
 
   describe('findOne', () => {
-    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const idPoll = '550e8400-e29b-41d4-a716-446655440000';
 
     it('should return a single poll', async () => {
       const expectedPoll = {
-        uuid,
+        idPoll,
         title: 'Test Poll',
-        uuidMessage: '12345678901234567',
+        idMessage: '12345678901234567',
         isTemplate: false,
         isAnonymous: false,
         isClosed: false,
@@ -144,24 +144,24 @@ describe('PollsService', () => {
 
       mockPollRepository.findOneBy.mockResolvedValue(expectedPoll);
 
-      const result = await service.findOne(uuid);
+      const result = await service.findOne(idPoll);
 
       expect(result).toEqual(expectedPoll);
-      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ idPoll });
     });
 
     it('should throw NotFoundException when poll is not found', async () => {
       mockPollRepository.findOneBy.mockResolvedValue(null);
 
-      await expect(service.findOne(uuid)).rejects.toThrow(
-        new NotFoundException(`The poll with UUID "${uuid}" was not found`),
+      await expect(service.findOne(idPoll)).rejects.toThrow(
+        new NotFoundException(`The poll with id "${idPoll}" was not found`),
       );
-      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ idPoll });
     });
   });
 
   describe('update', () => {
-    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const idPoll = '550e8400-e29b-41d4-a716-446655440000';
     const updatePollDto: UpdatePollDto = {
       title: 'Updated Poll',
       isAnonymous: true,
@@ -181,9 +181,9 @@ describe('PollsService', () => {
 
     it('should update a poll', async () => {
       const existingPoll = {
-        uuid,
+        idPoll,
         title: 'Original Poll',
-        uuidMessage: '12345678901234567',
+        idMessage: '12345678901234567',
         isTemplate: false,
         isAnonymous: false,
         isClosed: false,
@@ -202,10 +202,10 @@ describe('PollsService', () => {
       mockPollRepository.findOneBy.mockResolvedValue(existingPoll);
       mockPollRepository.save.mockResolvedValue(updatedPoll);
 
-      const result = await service.update(uuid, updatePollDto);
+      const result = await service.update(idPoll, updatePollDto);
 
       expect(result).toEqual(updatedPoll);
-      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ idPoll });
       expect(mockPollRepository.save).toHaveBeenCalledWith(expect.objectContaining({
         ...existingPoll,
         ...updatePollDto,
@@ -215,21 +215,21 @@ describe('PollsService', () => {
     it('should throw NotFoundException when poll to update is not found', async () => {
       mockPollRepository.findOneBy.mockResolvedValue(null);
 
-      await expect(service.update(uuid, updatePollDto)).rejects.toThrow(
-        new NotFoundException(`The poll with UUID "${uuid}" was not found`),
+      await expect(service.update(idPoll, updatePollDto)).rejects.toThrow(
+        new NotFoundException(`The poll with id "${idPoll}" was not found`),
       );
-      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ idPoll });
     });
   });
 
   describe('remove', () => {
-    const uuid = '550e8400-e29b-41d4-a716-446655440000';
+    const idPoll = '550e8400-e29b-41d4-a716-446655440000';
 
     it('should delete a poll', async () => {
       const existingPoll = {
-        uuid,
+        idPoll,
         title: 'Poll to Delete',
-        uuidMessage: '12345678901234567',
+        idMessage: '12345678901234567',
         isTemplate: false,
         isAnonymous: false,
         isClosed: false,
@@ -244,20 +244,20 @@ describe('PollsService', () => {
       mockPollRepository.findOneBy.mockResolvedValue(existingPoll);
       mockPollRepository.delete.mockResolvedValue(deleteResult);
 
-      const result = await service.remove(uuid);
+      const result = await service.remove(idPoll);
 
       expect(result).toEqual(deleteResult);
-      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ uuid });
-      expect(mockPollRepository.delete).toHaveBeenCalledWith({ uuid });
+      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ idPoll });
+      expect(mockPollRepository.delete).toHaveBeenCalledWith({ idPoll });
     });
 
     it('should throw NotFoundException when poll to delete is not found', async () => {
       mockPollRepository.findOneBy.mockResolvedValue(null);
 
-      await expect(service.remove(uuid)).rejects.toThrow(
-        new NotFoundException(`The poll with UUID "${uuid}" was not found`),
+      await expect(service.remove(idPoll)).rejects.toThrow(
+        new NotFoundException(`The poll with id "${idPoll}" was not found`),
       );
-      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ uuid });
+      expect(mockPollRepository.findOneBy).toHaveBeenCalledWith({ idPoll });
     });
   });
 });

--- a/src/polls/polls.service.ts
+++ b/src/polls/polls.service.ts
@@ -4,7 +4,7 @@ import { CreatePollDto } from './dto/create-poll.dto';
 import { UpdatePollDto } from './dto/update-poll.dto';
 import { Poll } from './entities/poll.entity';
 import { Repository } from 'typeorm';
-import { isUUID, IsUUID } from 'class-validator';
+import { isUUID } from 'class-validator';
 
 @Injectable()
 export class PollsService {
@@ -22,37 +22,37 @@ export class PollsService {
     return this.pollRepository.find();
   }
 
-  async findOne(uuid: string): Promise<Poll> {
-    if(!isUUID(uuid)) {
-      throw new NotFoundException(`The poll with UUID "${uuid}" was not found`);
+  async findOne(idPoll: string): Promise<Poll> {
+    if(!isUUID(idPoll)) {
+      throw new NotFoundException(`The poll with id "${idPoll}" was not found`);
     }
-    const poll = await this.pollRepository.findOneBy({ uuid });
+    const poll = await this.pollRepository.findOneBy({ idPoll });
     if (!poll) {
-      throw new NotFoundException(`The poll with UUID "${uuid}" was not found`);
+      throw new NotFoundException(`The poll with id "${idPoll}" was not found`);
     }
     return poll;
   }
 
-  async update(uuid: string, updatePollDto: UpdatePollDto) {
-    if(!isUUID(uuid)) {
-      throw new NotFoundException(`The poll with UUID "${uuid}" was not found`);
+  async update(idPoll: string, updatePollDto: UpdatePollDto) {
+    if(!isUUID(idPoll)) {
+      throw new NotFoundException(`The poll with id "${idPoll}" was not found`);
     }
-    const poll = await this.pollRepository.findOneBy({ uuid });
+    const poll = await this.pollRepository.findOneBy({ idPoll });
     if (!poll) {
-      throw new NotFoundException(`The poll with UUID "${uuid}" was not found`);
+      throw new NotFoundException(`The poll with id "${idPoll}" was not found`);
     }
     Object.assign(poll, updatePollDto);
     return this.pollRepository.save(poll);
   }
 
-  async remove(uuid: string) {
-    if(!isUUID(uuid)) {
-      throw new NotFoundException(`The poll with UUID "${uuid}" was not found`);
+  async remove(idPoll: string) {
+    if(!isUUID(idPoll)) {
+      throw new NotFoundException(`The poll with id "${idPoll}" was not found`);
     }
-    const poll = await this.pollRepository.findOneBy({ uuid });
+    const poll = await this.pollRepository.findOneBy({ idPoll });
     if (!poll) {
-      throw new NotFoundException(`The poll with UUID "${uuid}" was not found`);
+      throw new NotFoundException(`The poll with id "${idPoll}" was not found`);
     }
-    return this.pollRepository.delete({uuid})
+    return this.pollRepository.delete({idPoll})
   }
 }

--- a/src/promotions/dto/create-promotion.dto.ts
+++ b/src/promotions/dto/create-promotion.dto.ts
@@ -1,19 +1,19 @@
 import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
-import { IsDate } from 'class-validator';
+import { IsDate, IsNotEmpty, IsString, Length, Matches } from 'class-validator';
 import { PickableDtoFields } from 'src/utils/pickable-dto-fields';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 
-export class CreatePromotionDto extends PickType(IntersectionType(PickableDtoFields, PickableDiscordUUIDFields, PickableInternUUIDFields), [
+export class CreatePromotionDto extends PickType(IntersectionType(PickableDtoFields, PickableDiscordIdFields, PickableInternIdFields), [
+  'idPromotion',
   'name',
-  'uuidRole',
-  'uuidGuild',
-  'uuidCourse',
-  'uuidCampus',
-  'uuidCategory'
+  'idRole',
+  'idGuild',
+  'idCourse',
+  'idCampus',
+  'idCategory'
 ]) {
-
   @ApiProperty({
     description: 'Date de début de la promotion',
     example: '2024-01-01T00:00:00.000Z'

--- a/src/promotions/entities/promotion.entity.ts
+++ b/src/promotions/entities/promotion.entity.ts
@@ -1,4 +1,4 @@
-import { Entity, Column, PrimaryGeneratedColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, OneToOne, ManyToMany, JoinTable } from 'typeorm';
+import { Entity, Column, PrimaryColumn, CreateDateColumn, UpdateDateColumn, ManyToOne, JoinColumn, OneToOne, ManyToMany, JoinTable } from 'typeorm';
 import { ApiProperty } from '@nestjs/swagger';
 import { Course } from '../../courses/entities/course.entity';
 import { Guild } from '../../guilds/entities/guild.entity';
@@ -7,14 +7,14 @@ import { Campus } from 'src/campuses/entities/campus.entity';
 import { Category } from 'src/categories/entities/category.entity';
 import { Member } from 'src/members/entities/member.entity';
 
-@Entity('Promotions')
+@Entity('promotions')
 export class Promotion {
   @ApiProperty({
-    description: 'UUID unique de la promotion',
-    example: '123e4567-e89b-12d3-a456-426614174000'
+    description: 'SF unique de la promotion',
+    example: '123456789012345678'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_promotion' })
-  uuid: string;
+  @PrimaryColumn({ type: 'varchar', length: 19, name: 'id_promotion' })
+  idPromotion: string;
 
   @ApiProperty({
     description: 'Nom de la promotion',
@@ -23,6 +23,17 @@ export class Promotion {
   })
   @Column({ type: 'varchar', length: 100 })
   name: string;
+
+  @ApiProperty({
+    description: 'Statut de la promotion',
+    example: true,
+    default: true
+  })
+  @Column({ 
+    type: 'boolean', 
+    default: true
+  })
+  isActive: boolean;
 
   @ApiProperty({
     description: 'Date de début de la promotion',
@@ -39,19 +50,6 @@ export class Promotion {
   endDate: Date;
 
   @ApiProperty({
-    description: 'Statut de la promotion',
-    example: 'active',
-    enum: ['active', 'completed', 'cancelled'],
-    default: 'active'
-  })
-  @Column({ 
-    type: 'varchar', 
-    length: 20, 
-    default: 'active'
-  })
-  status: string;
-
-  @ApiProperty({
     description: 'Date de création',
     example: '2024-02-17T12:00:00Z'
   })
@@ -66,80 +64,80 @@ export class Promotion {
   updatedAt: Date;
   
   @ApiProperty({
-    description: 'UUID unique de la formation',
+    description: 'id unique de la formation',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ name: 'uuid_course', type: 'uuid' })
-  uuidCourse: string;
+  @Column({ name: 'id_course', type: 'uuid' })
+  idCourse: string;
 
   @ApiProperty({
     description: 'Formation associée à la promotion',
     type: () => Course
   })
   @ManyToOne(() => Course, course => course.promotions)
-  @JoinColumn({ name: 'uuid_course' })
+  @JoinColumn({ name: 'id_course' })
   course: Course;
 
   @ApiProperty({
-    description: 'UUID du serveur Discord associé',
+    description: 'id du serveur Discord associé',
     example: '123456789012345678'
   })
-  @Column({ name: 'uuid_guild', type: 'varchar', length: 19, nullable: true })
-  uuidGuild: string;
+  @Column({ name: 'id_guild', type: 'varchar', length: 19, nullable: true })
+  idGuild: string;
 
   @ApiProperty({
     description: 'Serveur Discord associé à la promotion',
     type: () => Guild
   })
   @ManyToOne(() => Guild, guild => guild.promotions)
-  @JoinColumn({ name: 'uuid_guild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 
   @ApiProperty({
-    description: 'UUID du rôle Discord associé',
+    description: 'id du rôle Discord associé',
     example: '123456789012345678'
   })
-  @Column({ name: 'uuid_role', type: 'varchar', length: 19, nullable: true })
-  uuidRole: string;
+  @Column({ name: 'id_role', type: 'varchar', length: 19, nullable: true })
+  idRole: string;
 
   @ApiProperty({
     description: 'Rôle Discord associé à la promotion',
     type: () => Role
   })
   @OneToOne(() => Role, role => role.promotion)
-  @JoinColumn({ name: 'uuid_role' })
+  @JoinColumn({ name: 'id_role' })
   role: Role;
 
   // Nouvelle relation avec Campus
   @ApiProperty({
-    description: 'UUID du campus associé',
+    description: 'id du campus associé',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ name: 'uuid_campus', type: 'uuid', nullable: true })
-  uuidCampus: string;
+  @Column({ name: 'id_campus', type: 'uuid', nullable: true })
+  idCampus: string;
 
   @ApiProperty({
     description: 'Campus associé à la promotion',
     type: () => Campus
   })
   @ManyToOne(() => Campus)
-  @JoinColumn({ name: 'uuid_campus' })
+  @JoinColumn({ name: 'id_campus' })
   campus: Campus;
 
   // Nouvelle relation avec Category
   @ApiProperty({
-    description: 'UUID de la catégorie Discord associée',
+    description: 'id de la catégorie Discord associée',
     example: '123456789012345678'
   })
-  @Column({ name: 'uuid_category', type: 'varchar', length: 19, nullable: true })
-  uuidCategory: string;
+  @Column({ name: 'id_category', type: 'varchar', length: 19, nullable: true })
+  idCategory: string;
 
   @ApiProperty({
     description: 'Catégorie Discord associée à la promotion',
     type: () => Category
   })
   @OneToOne(() => Category)
-  @JoinColumn({ name: 'uuid_category' })
+  @JoinColumn({ name: 'id_category' })
   category: Category;
 
   // Nouvelles relations ManyToMany avec Member
@@ -150,8 +148,8 @@ export class Promotion {
   @ManyToMany(() => Member)
   @JoinTable({
     name: 'promotions_followers',
-    joinColumns: [{ name: 'uuid_promotion', referencedColumnName: 'uuid' }],
-    inverseJoinColumns: [{ name: 'uuid_member', referencedColumnName: 'uuidMember' }]
+    joinColumns: [{ name: 'id_promotion', referencedColumnName: 'idPromotion' }],
+    inverseJoinColumns: [{ name: 'id_member', referencedColumnName: 'idMember' }]
   })
   followers: Member[];
 
@@ -162,8 +160,8 @@ export class Promotion {
   @ManyToMany(() => Member)
   @JoinTable({
     name: 'promotions_managers',
-    joinColumns: [{ name: 'uuid_promotion', referencedColumnName: 'uuid' }],
-    inverseJoinColumns: [{ name: 'uuid_member', referencedColumnName: 'uuidMember' }]
+    joinColumns: [{ name: 'id_promotion', referencedColumnName: 'idPromotion' }],
+    inverseJoinColumns: [{ name: 'id_member', referencedColumnName: 'idMember' }]
   })
   managers: Member[];
 }

--- a/src/promotions/promotions.controller.ts
+++ b/src/promotions/promotions.controller.ts
@@ -38,59 +38,59 @@ export class PromotionsController {
     return this.promotionsService.findAll();
   }
 
-  @Get(':uuid')
-  @ApiOperation({ summary: 'Récupérer une promotion par son UUID' })
+  @Get(':id')
+  @ApiOperation({ summary: 'Récupérer une promotion par son id' })
   @ApiResponse({ status: 200, description: 'Promotion récupérée avec succès.', type: Promotion })
   @ApiResponse({ status: 404, description: 'Promotion non trouvée' })
-  findOne(@Param('uuid') uuid: string) {
-    return this.promotionsService.findOne(uuid);
+  findOne(@Param('id') idPromotion: string) {
+    return this.promotionsService.findOne(idPromotion);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ summary: 'Mettre à jour une promotion' })
   @ApiResponse({ status: 200, description: 'La promotion a été mise à jour avec succès.', type: Promotion })
   @ApiResponse({ status: 404, description: 'Promotion non trouvée' })
-  async update(@Param('uuid') uuid: string, @Body() updatePromotionDto: UpdatePromotionDto) {
-    const promotion = await this.promotionsService.update(uuid, updatePromotionDto);
+  async update(@Param('id') idPromotion: string, @Body() updatePromotionDto: UpdatePromotionDto) {
+    const promotion = await this.promotionsService.update(idPromotion, updatePromotionDto);
     if (!promotion) {
-      throw new NotFoundException(`Promotion with UUID "${uuid}" not found`);
+      throw new NotFoundException(`Promotion with id "${idPromotion}" not found`);
     }
     return promotion;
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ summary: 'Supprimer une promotion' })
   @ApiResponse({ status: 200, description: 'La promotion a été supprimée avec succès.' })
   @ApiResponse({ status: 404, description: 'Promotion non trouvée' })
-  remove(@Param('uuid') uuid: string) {
-    return this.promotionsService.remove(uuid);
+  remove(@Param('id') idPromotion: string) {
+    return this.promotionsService.remove(idPromotion);
   }
 
-  @Post(':uuid_promotion/followers/:uuid_member')
+  @Post(':id/followers/:idMember')
   @ApiOperation({ summary: 'Ajouter un membre comme follower d\'une promotion' })
-  @ApiParam({ name: 'uuid_promotion', description: 'UUID de la promotion' })
-  @ApiParam({ name: 'uuid_member', description: 'UUID du membre à ajouter comme follower' })
+  @ApiParam({ name: 'id_promotion', description: 'id de la promotion' })
+  @ApiParam({ name: 'id_member', description: 'id du membre à ajouter comme follower' })
   @ApiResponse({ status: 200, description: 'Le membre a été ajouté comme follower avec succès.', type: Promotion })
   @ApiResponse({ status: 404, description: 'Promotion ou membre non trouvé' })
   @ApiResponse({ status: 400, description: 'Le membre est déjà follower de cette promotion' })
   addFollower(
-    @Param('uuid_promotion') uuidPromotion: string,
-    @Param('uuid_member') uuidMember: string,
+    @Param('id') idPromotion: string,
+    @Param('idMember') idMember: string,
   ) {
-    return this.promotionsService.addFollower(uuidPromotion, uuidMember);
+    return this.promotionsService.addFollower(idPromotion, idMember);
   }
 
-  @Post(':uuid_promotion/managers/:uuid_member')
+  @Post(':id/managers/:idMember')
   @ApiOperation({ summary: 'Ajouter un membre comme manager d\'une promotion' })
-  @ApiParam({ name: 'uuid_promotion', description: 'UUID de la promotion' })
-  @ApiParam({ name: 'uuid_member', description: 'UUID du membre à ajouter comme manager' })
+  @ApiParam({ name: 'id', description: 'id de la promotion' })
+  @ApiParam({ name: 'idMember', description: 'id du membre à ajouter comme manager' })
   @ApiResponse({ status: 200, description: 'Le membre a été ajouté comme manager avec succès.', type: Promotion })
   @ApiResponse({ status: 404, description: 'Promotion ou membre non trouvé' })
   @ApiResponse({ status: 400, description: 'Le membre est déjà manager de cette promotion' })
   addManager(
-    @Param('uuid_promotion') uuidPromotion: string,
-    @Param('uuid_member') uuidMember: string,
+    @Param('id') idPromotion: string,
+    @Param('idMember') idMember: string,
   ) {
-    return this.promotionsService.addManager(uuidPromotion, uuidMember);
+    return this.promotionsService.addManager(idPromotion, idMember);
   }
 } 

--- a/src/promotions/promotions.service.spec.ts
+++ b/src/promotions/promotions.service.spec.ts
@@ -69,15 +69,15 @@ describe('PromotionsService', () => {
         name: 'Test Promotion',
         startDate: new Date(),
         endDate: new Date(),
-        status: 'active',
-        uuidCourse: '123e4567-e89b-12d3-a456-426614174000',
-        uuidGuild: '123456789012345678',
-        uuidRole: '234567890123456789',
+        isActive: true,
+        idCourse: '123e4567-e89b-12d3-a456-426614174000',
+        idGuild: '123456789012345678',
+        idRole: '234567890123456789',
       };
 
       const newRole = {
-        uuidRole: '234567890123456789',
-        uuidGuild: '123456789012345678',
+        idRole: '234567890123456789',
+        idGuild: '123456789012345678',
         name: 'Test Promotion',
         memberCount: 0,
         rolePosition: 0,
@@ -86,7 +86,7 @@ describe('PromotionsService', () => {
       };
 
       const savedPromotion = {
-        uuid: '123e4567-e89b-12d3-a456-426614174001',
+        id: '123e4567-e89b-12d3-a456-426614174001',
         ...createPromotionDto,
       };
 
@@ -98,14 +98,14 @@ describe('PromotionsService', () => {
       const result = await service.create(createPromotionDto);
 
       expect(mockRoleRepository.create).toHaveBeenCalledWith(expect.objectContaining({
-        uuidRole: createPromotionDto.uuidRole,
-        uuidGuild: createPromotionDto.uuidGuild,
+        idRole: createPromotionDto.idRole,
+        idGuild: createPromotionDto.idGuild,
         name: createPromotionDto.name,
       }));
       expect(mockRoleRepository.save).toHaveBeenCalledWith(newRole);
       expect(mockPromotionRepository.create).toHaveBeenCalledWith(expect.objectContaining({
         ...createPromotionDto,
-        uuidRole: newRole.uuidRole,
+        idRole: newRole.idRole,
       }));
       expect(mockPromotionRepository.save).toHaveBeenCalledWith(savedPromotion);
       expect(result).toEqual(savedPromotion);
@@ -115,8 +115,8 @@ describe('PromotionsService', () => {
   describe('findAll', () => {
     it('should return an array of promotions with relations', async () => {
       const promotions = [
-        { uuid: '123e4567-e89b-12d3-a456-426614174001', name: 'Promotion 1' },
-        { uuid: '123e4567-e89b-12d3-a456-426614174002', name: 'Promotion 2' },
+        { idPromotion: '123e4567-e89b-12d3-a456-426614174001', name: 'Promotion 1' },
+        { idPromotion: '123e4567-e89b-12d3-a456-426614174002', name: 'Promotion 2' },
       ];
       mockPromotionRepository.find.mockResolvedValue(promotions);
 
@@ -131,13 +131,13 @@ describe('PromotionsService', () => {
 
   describe('findOne', () => {
     it('should return a single promotion with relations', async () => {
-      const promotion = { uuid: '123e4567-e89b-12d3-a456-426614174001', name: 'Promotion 1' };
+      const promotion = { idPromotion: '123e4567-e89b-12d3-a456-426614174001', name: 'Promotion 1' };
       mockPromotionRepository.findOne.mockResolvedValue(promotion);
 
       const result = await service.findOne('123e4567-e89b-12d3-a456-426614174001');
 
       expect(mockPromotionRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: '123e4567-e89b-12d3-a456-426614174001' },
+        where: { idPromotion: '123e4567-e89b-12d3-a456-426614174001' },
         relations: ['followers', 'managers', 'category', 'course', 'campus', 'role', 'guild']
       });
       expect(result).toEqual(promotion);
@@ -146,7 +146,7 @@ describe('PromotionsService', () => {
 
   describe('update', () => {
     it('should update a promotion', async () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idPromotion = '123e4567-e89b-12d3-a456-426614174001';
       const updatePromotionDto: UpdatePromotionDto = { 
         name: 'Updated Promotion',
         startDate: new Date('2024-02-01'),
@@ -154,7 +154,7 @@ describe('PromotionsService', () => {
       };
       
       const existingPromotion = { 
-        uuid,
+        idPromotion,
         name: 'Old Promotion',
         startDate: new Date('2024-01-01'),
         endDate: new Date('2024-11-30'),
@@ -170,10 +170,10 @@ describe('PromotionsService', () => {
       mockPromotionRepository.findOne.mockResolvedValue(existingPromotion);
       mockPromotionRepository.save.mockResolvedValue(updatedPromotion);
 
-      const result = await service.update(uuid, updatePromotionDto);
+      const result = await service.update(idPromotion, updatePromotionDto);
 
       expect(mockPromotionRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid },
+        where: { idPromotion },
         relations: ['followers', 'managers', 'category', 'course', 'campus', 'role', 'guild']
       });
       expect(mockPromotionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
@@ -187,16 +187,16 @@ describe('PromotionsService', () => {
 
   describe('remove', () => {
     it('should remove a promotion', async () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
-      const promotion = { uuid, name: 'Promotion to Remove' };
+      const idPromotion = '123e4567-e89b-12d3-a456-426614174001';
+      const promotion = { idPromotion, name: 'Promotion to Remove' };
       
       mockPromotionRepository.findOne.mockResolvedValue(promotion);
       mockPromotionRepository.remove.mockResolvedValue(promotion);
 
-      const result = await service.remove(uuid);
+      const result = await service.remove(idPromotion);
 
       expect(mockPromotionRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid },
+        where: { idPromotion },
         relations: ['followers', 'managers', 'category', 'course', 'campus', 'role', 'guild']
       });
       expect(mockPromotionRepository.remove).toHaveBeenCalledWith(promotion);
@@ -206,16 +206,16 @@ describe('PromotionsService', () => {
 
   describe('addFollower', () => {
     it('should add a member as follower to a promotion', async () => {
-      const uuidPromotion = '123e4567-e89b-12d3-a456-426614174001';
-      const uuidMember = '123e4567-e89b-12d3-a456-426614174002';
+      const idPromotion = '123e4567-e89b-12d3-a456-426614174001';
+      const idMember = '123e4567-e89b-12d3-a456-426614174002';
       
       const promotion = { 
-        uuid: uuidPromotion, 
+        idPromotion: idPromotion, 
         name: 'Test Promotion',
         followers: [],
       };
       
-      const member = { uuidMember, guildUsername: 'TestUser' };
+      const member = { idMember, guildUsername: 'TestUser' };
       const updatedPromotion = { 
         ...promotion,
         followers: [member],
@@ -225,13 +225,13 @@ describe('PromotionsService', () => {
       mockMemberRepository.findOneBy.mockResolvedValue(member);
       mockPromotionRepository.save.mockResolvedValue(updatedPromotion);
 
-      const result = await service.addFollower(uuidPromotion, uuidMember);
+      const result = await service.addFollower(idPromotion, idMember);
 
       expect(mockPromotionRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuidPromotion },
+        where: { idPromotion: idPromotion },
         relations: ['followers']
       });
-      expect(mockMemberRepository.findOneBy).toHaveBeenCalledWith({ uuidMember });
+      expect(mockMemberRepository.findOneBy).toHaveBeenCalledWith({ idMember });
       expect(mockPromotionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
         ...promotion,
         followers: [member],
@@ -242,16 +242,16 @@ describe('PromotionsService', () => {
 
   describe('addManager', () => {
     it('should add a member as manager to a promotion', async () => {
-      const uuidPromotion = '123e4567-e89b-12d3-a456-426614174001';
-      const uuidMember = '123e4567-e89b-12d3-a456-426614174002';
+      const idPromotion = '123e4567-e89b-12d3-a456-426614174001';
+      const idMember = '123e4567-e89b-12d3-a456-426614174002';
       
       const promotion = { 
-        uuid: uuidPromotion, 
+        idPromotion: idPromotion, 
         name: 'Test Promotion',
         managers: [],
       };
       
-      const member = { uuidMember, guildUsername: 'TestUser' };
+      const member = { idMember, guildUsername: 'TestUser' };
       const updatedPromotion = { 
         ...promotion,
         managers: [member],
@@ -261,13 +261,13 @@ describe('PromotionsService', () => {
       mockMemberRepository.findOneBy.mockResolvedValue(member);
       mockPromotionRepository.save.mockResolvedValue(updatedPromotion);
 
-      const result = await service.addManager(uuidPromotion, uuidMember);
+      const result = await service.addManager(idPromotion, idMember);
 
       expect(mockPromotionRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: uuidPromotion },
+        where: { idPromotion: idPromotion },
         relations: ['managers']
       });
-      expect(mockMemberRepository.findOneBy).toHaveBeenCalledWith({ uuidMember });
+      expect(mockMemberRepository.findOneBy).toHaveBeenCalledWith({ idMember });
       expect(mockPromotionRepository.save).toHaveBeenCalledWith(expect.objectContaining({
         ...promotion,
         managers: [member],

--- a/src/promotions/promotions.service.ts
+++ b/src/promotions/promotions.service.ts
@@ -24,8 +24,8 @@ export class PromotionsService {
     try {
       // Création du rôle associé à la promotion
       const newRole = this.roleRepository.create({
-        uuidRole: createPromotionDto.uuidRole, // UUID fourni par le DTO
-        uuidGuild: createPromotionDto.uuidGuild, // Lié à la guilde
+        idRole: createPromotionDto.idRole, // id fourni par le DTO
+        idGuild: createPromotionDto.idGuild, // Lié à la guilde
         name: createPromotionDto.name, // Même nom que la promotion
         memberCount: 0,
         rolePosition: 0,
@@ -39,7 +39,7 @@ export class PromotionsService {
       // Création de la promotion avec le rôle associé
       const newPromotion = this.promotionRepository.create({
         ...createPromotionDto,
-        uuidRole: savedRole.uuidRole, // Associe le rôle créé à la promotion
+        idRole: savedRole.idRole, // Associe le rôle créé à la promotion
       });
 
       return await this.promotionRepository.save(newPromotion);
@@ -54,20 +54,20 @@ export class PromotionsService {
     });
   }
 
-  async findOne(uuid: string): Promise<Promotion> {
+  async findOne(idPromotion: string): Promise<Promotion> {
     const promotion = await this.promotionRepository.findOne({
-      where: { uuid },
+      where: { idPromotion },
       relations: ['followers', 'managers', 'category', 'course', 'campus', 'role', 'guild']
     });
     
     if (!promotion) {
-      throw new NotFoundException(`Promotion avec UUID ${uuid} non trouvée`);
+      throw new NotFoundException(`Promotion avec idPromotion ${idPromotion} non trouvée`);
     }
     return promotion;
   }
 
-  async update(uuid: string, updatePromotionDto: UpdatePromotionDto): Promise<Promotion> {
-    const promotion = await this.findOne(uuid);
+  async update(idPromotion: string, updatePromotionDto: UpdatePromotionDto): Promise<Promotion> {
+    const promotion = await this.findOne(idPromotion);
 
     // Mise à jour des champs autorisés
     const { name, startDate, endDate } = updatePromotionDto;
@@ -79,28 +79,28 @@ export class PromotionsService {
     return await this.promotionRepository.save(promotion);
   }
 
-  async remove(uuid: string) {
-    const promotion = await this.findOne(uuid);
+  async remove(idPromotion: string) {
+    const promotion = await this.findOne(idPromotion);
     return await this.promotionRepository.remove(promotion);
   }
 
-  async addFollower(uuidPromotion: string, uuidMember: string): Promise<Promotion> {
+  async addFollower(idPromotion: string, idMember: string): Promise<Promotion> {
     const promotion = await this.promotionRepository.findOne({
-      where: { uuid: uuidPromotion },
+      where: { idPromotion: idPromotion },
       relations: ['followers']
     });
 
     if (!promotion) {
-      throw new NotFoundException(`Promotion avec UUID ${uuidPromotion} non trouvée`);
+      throw new NotFoundException(`Promotion avec id ${idPromotion} non trouvée`);
     }
 
-    const member = await this.memberRepository.findOneBy({ uuidMember });
+    const member = await this.memberRepository.findOneBy({ idMember });
     if (!member) {
-      throw new NotFoundException(`Membre avec UUID ${uuidMember} non trouvé`);
+      throw new NotFoundException(`Membre avec id ${idMember} non trouvé`);
     }
 
     // Vérifier si le membre est déjà follower
-    if (promotion.followers && promotion.followers.some(follower => follower.uuidMember === uuidMember)) {
+    if (promotion.followers && promotion.followers.some(follower => follower.idMember === idMember)) {
       throw new BadRequestException(`Le membre est déjà follower de cette promotion`);
     }
 
@@ -116,23 +116,23 @@ export class PromotionsService {
     return await this.promotionRepository.save(promotion);
   }
 
-  async addManager(uuidPromotion: string, uuidMember: string): Promise<Promotion> {
+  async addManager(idPromotion: string, idMember: string): Promise<Promotion> {
     const promotion = await this.promotionRepository.findOne({
-      where: { uuid: uuidPromotion },
+      where: { idPromotion: idPromotion },
       relations: ['managers']
     });
 
     if (!promotion) {
-      throw new NotFoundException(`Promotion avec UUID ${uuidPromotion} non trouvée`);
+      throw new NotFoundException(`Promotion avec id ${idPromotion} non trouvée`);
     }
 
-    const member = await this.memberRepository.findOneBy({ uuidMember });
+    const member = await this.memberRepository.findOneBy({ idMember });
     if (!member) {
-      throw new NotFoundException(`Membre avec UUID ${uuidMember} non trouvé`);
+      throw new NotFoundException(`Membre avec id ${idMember} non trouvé`);
     }
 
     // Vérifier si le membre est déjà manager
-    if (promotion.managers && promotion.managers.some(manager => manager.uuidMember === uuidMember)) {
+    if (promotion.managers && promotion.managers.some(manager => manager.idMember === idMember)) {
       throw new BadRequestException(`Le membre est déjà manager de cette promotion`);
     }
 

--- a/src/question-templates/dto/create-question-poll-template.dto.ts
+++ b/src/question-templates/dto/create-question-poll-template.dto.ts
@@ -2,12 +2,12 @@ import { IntersectionType, PickType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { MaxLength, IsBoolean, ValidateNested, ArrayMinSize } from 'class-validator';
 import { CreateAnswerDto } from 'src/answers/dto/create-answer.dto';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 import { CreateQuestionTemplateDto } from './create-question-template.dto';
 
 export class CreateQuestionPollTemplateDto extends IntersectionType(
     CreateQuestionTemplateDto,
-    PickType(PickableInternUUIDFields, ['uuidPollTemplate'])
+    PickType(PickableInternIdFields, ['idPollTemplate'])
 ) {
   @MaxLength(50)
   content: string;

--- a/src/question-templates/entities/question-template.entity.ts
+++ b/src/question-templates/entities/question-template.entity.ts
@@ -9,8 +9,8 @@ export class QuestionTemplate {
         description: 'Unique identifier of the question',
         example: '123e4567-e89b-12d3-a456-426614174000'
     })
-    @PrimaryGeneratedColumn('uuid', { name: 'uuid_question_template' })
-    uuid: string;
+    @PrimaryGeneratedColumn('uuid', { name: 'id_question_template' })
+    idQuestionTemplate: string;
     
     @ApiProperty({
         description: 'Content of the question template',
@@ -31,7 +31,7 @@ export class QuestionTemplate {
         type: () => PollTemplate
     })
     @ManyToOne(() => PollTemplate, (pollTemplate) => pollTemplate.questionTemplates, {onDelete: 'CASCADE'})
-    @JoinColumn({ name: 'uuid_poll_template' })
+    @JoinColumn({ name: 'id_poll_template' })
     pollTemplate: PollTemplate;
 
     @ApiProperty({

--- a/src/question-templates/question-templates.controller.ts
+++ b/src/question-templates/question-templates.controller.ts
@@ -17,18 +17,18 @@ export class QuestionTemplatesController {
     return this.questionTemplatesService.findAll();
   }
 
-  @Get(':uuid')
-  findOne(@Param('uuid') uuid: string) {
-    return this.questionTemplatesService.findOne(uuid);
+  @Get(':id')
+  findOne(@Param('id') idQuestionTemplate: string) {
+    return this.questionTemplatesService.findOne(idQuestionTemplate);
   }
 
-  @Put(':uuid')
-  update(@Param('uuid') uuid: string, @Body() updateQuestionTemplateDto: UpdateQuestionTemplateDto) {
-    return this.questionTemplatesService.update(uuid, updateQuestionTemplateDto);
+  @Put(':id')
+  update(@Param('id') idQuestionTemplate: string, @Body() updateQuestionTemplateDto: UpdateQuestionTemplateDto) {
+    return this.questionTemplatesService.update(idQuestionTemplate, updateQuestionTemplateDto);
   }
 
-  @Delete(':uuid')
-  remove(@Param('uuid') uuid: string) {
-    return this.questionTemplatesService.remove(uuid);
+  @Delete(':id')
+  remove(@Param('id') idQuestionTemplate: string) {
+    return this.questionTemplatesService.remove(idQuestionTemplate);
   }
 }

--- a/src/question-templates/question-templates.service.ts
+++ b/src/question-templates/question-templates.service.ts
@@ -22,39 +22,39 @@ export class QuestionTemplatesService {
     return this.questionTemplateRepository.find();
   }
 
-  async findOne(uuid: string): Promise<QuestionTemplate> {
-    if (!isUUID(uuid)) {
-      throw new NotFoundException(`The question template with UUID ${uuid} does not exist`);
+  async findOne(idQuestionTemplate: string): Promise<QuestionTemplate> {
+    if (!isUUID(idQuestionTemplate)) {
+      throw new NotFoundException(`The question template with id ${idQuestionTemplate} does not exist`);
     }
-    const questionTemplate = await this.questionTemplateRepository.findOne({ where: { uuid } });
+    const questionTemplate = await this.questionTemplateRepository.findOne({ where: { idQuestionTemplate } });
     if (!questionTemplate) {
-      throw new NotFoundException(`The question template with UUID ${uuid} does not exist`);
+      throw new NotFoundException(`The question template with id ${idQuestionTemplate} does not exist`);
     }
     return questionTemplate;
   }
 
-  async update(uuid: string, updateQuestionTemplateDto: UpdateQuestionTemplateDto) : Promise<QuestionTemplate> {
-    if (!isUUID(uuid)) {
-      throw new NotFoundException(`The question template with UUID ${uuid} does not exist`);
+  async update(idQuestionTemplate: string, updateQuestionTemplateDto: UpdateQuestionTemplateDto) : Promise<QuestionTemplate> {
+    if (!isUUID(idQuestionTemplate)) {
+      throw new NotFoundException(`The question template with id ${idQuestionTemplate} does not exist`);
     }
     const questionTemplate = await this.questionTemplateRepository.preload({
-      uuid,
+      idQuestionTemplate,
       ...updateQuestionTemplateDto
     })
     if (!questionTemplate) {
-      throw new NotFoundException(`The question template with UUID ${uuid} does not exist`);
+      throw new NotFoundException(`The question template with id ${idQuestionTemplate} does not exist`);
     }
     return this.questionTemplateRepository.save(questionTemplate); 
   }
 
-  async remove(uuid: string) : Promise<DeleteResult> {
-    if (!isUUID(uuid)) {
-      throw new NotFoundException(`The question template with UUID ${uuid} does not exist`);
+  async remove(idQuestionTemplate: string) : Promise<DeleteResult> {
+    if (!isUUID(idQuestionTemplate)) {
+      throw new NotFoundException(`The question template with id ${idQuestionTemplate} does not exist`);
     }
-    const questionTemplate = await this.questionTemplateRepository.findOne({ where: { uuid } });
+    const questionTemplate = await this.questionTemplateRepository.findOne({ where: { idQuestionTemplate } });
     if (!questionTemplate) {
-      throw new NotFoundException(`The question template with UUID ${uuid} does not exist`);
+      throw new NotFoundException(`The question template with id ${idQuestionTemplate} does not exist`);
     }
-    return await this.questionTemplateRepository.delete(uuid);
+    return await this.questionTemplateRepository.delete(idQuestionTemplate);
   }
 }

--- a/src/questions/dto/create-question-poll.dto.ts
+++ b/src/questions/dto/create-question-poll.dto.ts
@@ -2,12 +2,12 @@ import { IntersectionType, PickType } from '@nestjs/swagger';
 import { Type } from 'class-transformer';
 import { MaxLength, IsBoolean, ValidateNested, ArrayMinSize } from 'class-validator';
 import { CreateAnswerDto } from 'src/answers/dto/create-answer.dto';
-import { PickableInternUUIDFields } from 'src/utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from 'src/utils/pickable-intern-id-fields';
 import { CreateQuestionDto } from './create-question.dto';
 
 export class CreateQuestionPollDto extends IntersectionType(
     CreateQuestionDto,
-    PickType(PickableInternUUIDFields, ['uuidPoll'])
+    PickType(PickableInternIdFields, ['idPoll'])
 ) {
   @MaxLength(50)
   content: string;

--- a/src/questions/entities/question.entity.ts
+++ b/src/questions/entities/question.entity.ts
@@ -9,8 +9,8 @@ export class Question {
         description: 'Unique identifier of the question',
         example: '123e4567-e89b-12d3-a456-426614174000'
     })
-    @PrimaryGeneratedColumn('uuid', { name: 'uuid_question' })
-    uuid: string;
+    @PrimaryGeneratedColumn('uuid', { name: 'id_question' })
+    idQuestion: string;
     
     @ApiProperty({
         description: 'Content of the question',
@@ -31,7 +31,7 @@ export class Question {
         type: () => Poll
     })
     @ManyToOne(() => Poll, (poll) => poll.questions, {onDelete: 'CASCADE'})
-    @JoinColumn({ name: 'uuid_poll' })
+    @JoinColumn({ name: 'id_poll' })
     poll: Poll;
 
     @ApiProperty({

--- a/src/questions/questions.service.ts
+++ b/src/questions/questions.service.ts
@@ -21,12 +21,12 @@ export class QuestionsService {
     return this.questionRepository.find();
   }
 
-  findOne(uuid: string) {
-    return this.questionRepository.findOneBy({ uuid });
+  findOne(idQuestion: string) {
+    return this.questionRepository.findOneBy({ idQuestion });
   }
 
-  async update(uuid: string, UpdateQuestionDto: UpdateQuestionDto) {
-    const question = await this.questionRepository.findOneBy({ uuid });
+  async update(idQuestion: string, UpdateQuestionDto: UpdateQuestionDto) {
+    const question = await this.questionRepository.findOneBy({ idQuestion });
     if (!question) {
       return null;
     }
@@ -34,7 +34,7 @@ export class QuestionsService {
     return this.questionRepository.save(question);
   }
 
-  remove(uuid: string) {
-    return this.questionRepository.delete({uuid})
+  remove(idQuestion: string) {
+    return this.questionRepository.delete({idQuestion})
   }
 }

--- a/src/reports/dto/create-report.dto.spec.ts
+++ b/src/reports/dto/create-report.dto.spec.ts
@@ -4,14 +4,13 @@ import { ReportCategory } from '../entities/report.entity';
 import { describe, it, expect } from 'vitest';
 
 describe('CreateReportDto', () => {
-  it('should validate a correct DTO', async () => {
-    const dto = new CreateReportDto();
-    dto.category = ReportCategory.SPAM;
-    dto.reason = 'Test reason';
-    dto.status = 'pending';
+  const dto = new CreateReportDto();
+  dto.category = ReportCategory.SPAM;
+  dto.reason = 'Valid reason';
 
+  it('should validate a correct DTO', async () => {
     const errors = await validate(dto);
-    expect(errors.length).toBe(0);
+    expect(errors).toHaveLength(0);
   });
 
   describe('category validation', () => {
@@ -19,7 +18,6 @@ describe('CreateReportDto', () => {
       const dto = new CreateReportDto();
       dto.category = 'invalid' as ReportCategory;
       dto.reason = 'Test reason';
-      dto.status = 'pending';
 
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
@@ -29,7 +27,6 @@ describe('CreateReportDto', () => {
     it('should reject missing category', async () => {
       const dto = new CreateReportDto();
       dto.reason = 'Test reason';
-      dto.status = 'pending';
 
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
@@ -40,20 +37,17 @@ describe('CreateReportDto', () => {
   describe('reason validation', () => {
     it('should reject reason > 50 chars', async () => {
       const dto = new CreateReportDto();
-      dto.category = ReportCategory.SPAM;
       dto.reason = 'a'.repeat(51);
-      dto.status = 'pending';
 
       const errors = await validate(dto);
-      expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].constraints).toHaveProperty('maxLength');
+      const reasonErrors = errors.find(err => err.property === 'reason');
+      expect(reasonErrors?.constraints?.maxLength).toBeDefined();
     });
 
     it('should reject empty reason', async () => {
       const dto = new CreateReportDto();
       dto.category = ReportCategory.SPAM;
       dto.reason = '';
-      dto.status = 'pending';
 
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
@@ -63,7 +57,6 @@ describe('CreateReportDto', () => {
     it('should reject missing reason', async () => {
       const dto = new CreateReportDto();
       dto.category = ReportCategory.SPAM;
-      dto.status = 'pending';
 
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
@@ -76,7 +69,6 @@ describe('CreateReportDto', () => {
       const dto = new CreateReportDto();
       dto.category = ReportCategory.SPAM;
       dto.reason = 'Test reason';
-      dto.status = '';
 
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
@@ -93,4 +85,4 @@ describe('CreateReportDto', () => {
       expect(errors[0].constraints).toHaveProperty('isNotEmpty');
     });
   });
-}); 
+});

--- a/src/reports/dto/create-report.dto.ts
+++ b/src/reports/dto/create-report.dto.ts
@@ -1,10 +1,10 @@
 import { IsEnum, IsNotEmpty, IsString, MaxLength, ValidateIf, IsUUID } from 'class-validator';
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { ReportCategory, ReportType } from '../entities/report.entity';
-import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from '../../utils/pickable-intern-id-fields';
 
-export class CreateReportDto extends PickType(PickableInternUUIDFields, [
-  'uuidReporter'
+export class CreateReportDto extends PickType(PickableInternIdFields, [
+  'idReporter'
 ]) {
   @ApiProperty({
     description: 'Type de l\'élément signalé (ressource ou membre)',
@@ -38,22 +38,22 @@ export class CreateReportDto extends PickType(PickableInternUUIDFields, [
   reason: string;
 
   @ApiProperty({
-    description: 'UUID de la ressource signalée (requis uniquement si type = resource)',
+    description: 'id de la ressource signalée (requis uniquement si type = resource)',
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false
   })
   @ValidateIf(o => o.type === ReportType.RESOURCE)
   @IsUUID()
   @IsNotEmpty()
-  uuidResource?: string;
+  idResource?: string;
 
   @ApiProperty({
-    description: 'UUID du membre signalé (requis uniquement si type = member)',
+    description: 'id du membre signalé (requis uniquement si type = member)',
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false
   })
   @ValidateIf(o => o.type === ReportType.MEMBER)
   @IsUUID()
   @IsNotEmpty()
-  uuidReportedMember?: string;
+  idReportedMember?: string;
 } 

--- a/src/reports/dto/responses/report.response.dto.ts
+++ b/src/reports/dto/responses/report.response.dto.ts
@@ -8,7 +8,7 @@ export class ReportMemberResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidMember: string;
+  idMember: string;
 
   @ApiProperty({
     description: 'Nom d\'utilisateur sur le serveur',
@@ -38,10 +38,10 @@ export class ReportMemberResponseDto {
   status: string;
 
   @Exclude()
-  uuidDiscord: string;
+  idDiscord: string;
 
   @Exclude()
-  uuidGuild: string;
+  idGuild: string;
 
   @Exclude()
   xp: string;
@@ -53,7 +53,7 @@ export class ResourceResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidResource: string;
+  idResource: string;
 
   @ApiProperty({
     description: 'Titre de la ressource',
@@ -103,7 +103,7 @@ export class ReportResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidReport: string;
+  idReport: string;
 
   @ApiProperty({
     description: 'Type de signalement',

--- a/src/reports/entities/report.entity.ts
+++ b/src/reports/entities/report.entity.ts
@@ -19,11 +19,11 @@ export enum ReportCategory {
 @Unique(['reporter', 'resource', 'reportedMember'])
 export class Report {
   @ApiProperty({
-    description: 'UUID unique du signalement',
+    description: 'id unique du signalement',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_report' })
-  uuidReport: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_report' })
+  idReport: string;
 
   @ApiProperty({
     description: 'Type de l\'élément signalé (ressource ou membre)',
@@ -78,7 +78,7 @@ export class Report {
   updatedAt: Date;
 
   @ManyToOne(() => Member)
-  @JoinColumn({ name: 'reporter_uuid' })
+  @JoinColumn({ name: 'id_reporter' })
   @ApiProperty({ 
     description: 'Membre qui a effectué le signalement',
     type: () => Member
@@ -86,7 +86,7 @@ export class Report {
   reporter: Member;
 
   @ManyToOne(() => Resource, resource => resource.reports)
-  @JoinColumn({ name: 'resource_uuid' })
+  @JoinColumn({ name: 'id_resource' })
   @ApiProperty({ 
     description: 'Ressource signalée (uniquement si type = resource)',
     type: () => Resource,
@@ -95,7 +95,7 @@ export class Report {
   resource?: Resource;
 
   @ManyToOne(() => Member)
-  @JoinColumn({ name: 'reported_member_uuid' })
+  @JoinColumn({ name: 'id_reported_member' })
   @ApiProperty({ 
     description: 'Membre signalé (uniquement si type = member)',
     type: () => Member,

--- a/src/reports/reports.controller.ts
+++ b/src/reports/reports.controller.ts
@@ -40,14 +40,14 @@ export class ReportsController {
     return this.reportsService.findAll();
   }
 
-  @Get(':uuid_report')
+  @Get(':id')
   @ApiOperation({ 
-    summary: 'Récupérer un signalement par son UUID',
+    summary: 'Récupérer un signalement par son id',
     description: 'Retourne les détails d\'un signalement spécifique avec toutes ses relations.'
   })
   @ApiParam({ 
-    name: 'uuid_report',
-    description: 'UUID du signalement à récupérer',
+    name: 'id',
+    description: 'id du signalement à récupérer',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -56,18 +56,18 @@ export class ReportsController {
     type: ReportResponseDto 
   })
   @ApiResponse({ status: 404, description: 'Signalement non trouvé' })
-  findOne(@Param('uuid_report') uuid_report: string): Promise<ReportResponseDto> {
-    return this.reportsService.findOne(uuid_report);
+  findOne(@Param('id') id_report: string): Promise<ReportResponseDto> {
+    return this.reportsService.findOne(id_report);
   }
 
-  @Put(':uuid_report')
+  @Put(':id')
   @ApiOperation({ 
     summary: 'Mettre à jour un signalement',
     description: 'Cette fonctionnalité est réservée aux modérateurs.'
   })
   @ApiParam({ 
-    name: 'uuid_report',
-    description: 'UUID du signalement à mettre à jour',
+    name: 'id',
+    description: 'id du signalement à mettre à jour',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -78,18 +78,18 @@ export class ReportsController {
   @ApiResponse({ status: 400, description: 'Données invalides' })
   @ApiResponse({ status: 403, description: 'Action non autorisée' })
   @ApiResponse({ status: 404, description: 'Signalement non trouvé' })
-  update(@Param('uuid_report') uuid_report: string, @Body() updateReportDto: UpdateReportDto): Promise<ReportResponseDto> {
-    return this.reportsService.update(uuid_report, updateReportDto);
+  update(@Param('id') id_report: string, @Body() updateReportDto: UpdateReportDto): Promise<ReportResponseDto> {
+    return this.reportsService.update(id_report, updateReportDto);
   }
 
-  @Delete(':uuid_report')
+  @Delete(':id')
   @ApiOperation({ 
     summary: 'Supprimer un signalement',
     description: 'Un utilisateur ne peut supprimer que ses propres signalements.'
   })
   @ApiParam({ 
-    name: 'uuid_report',
-    description: 'UUID du signalement à supprimer',
+    name: 'id',
+    description: 'id du signalement à supprimer',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -98,7 +98,7 @@ export class ReportsController {
   })
   @ApiResponse({ status: 403, description: 'Action non autorisée' })
   @ApiResponse({ status: 404, description: 'Signalement non trouvé' })
-  remove(@Param('uuid_report') uuid_report: string, @Headers('X-Member-UUID') currentUserId: string): Promise<void> {
-    return this.reportsService.remove(uuid_report, currentUserId);
+    remove(@Param('id') id_report: string, @Headers('X-Member-UUID') currentUserId: string): Promise<void> {
+    return this.reportsService.remove(id_report, currentUserId);
   }
 } 

--- a/src/reports/reports.service.spec.ts
+++ b/src/reports/reports.service.spec.ts
@@ -64,13 +64,13 @@ describe('ReportsService', () => {
       it('should successfully create a resource report', async () => {
         // Arrange
         const mockReporter = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           guildUsername: 'reporter',
           status: 'active',
         };
 
         const mockResource = {
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
           title: 'Reported Resource',
           status: 'active',
         };
@@ -79,12 +79,12 @@ describe('ReportsService', () => {
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
-          uuidReporter: mockReporter.uuidMember,
-          uuidResource: mockResource.uuidResource,
+          idReporter: mockReporter.idMember,
+          idResource: mockResource.idResource,
         };
 
         const mockReport = {
-          uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+          idReport: '123e4567-e89b-12d3-a456-426614174002',
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
@@ -121,15 +121,15 @@ describe('ReportsService', () => {
 
         // Assert
         expect(mockMembersRepository.findOne).toHaveBeenCalledWith({
-          where: { uuidMember: mockReporter.uuidMember }
+          where: { idMember: mockReporter.idMember }
         });
         expect(mockResourcesRepository.findOne).toHaveBeenCalledWith({
-          where: { uuidResource: mockResource.uuidResource }
+          where: { idResource: mockResource.idResource }
         });
         expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
           where: {
-            reporter: { uuidMember: mockReporter.uuidMember },
-            resource: { uuidResource: mockResource.uuidResource }
+            reporter: { idMember: mockReporter.idMember },
+            resource: { idResource: mockResource.idResource }
           },
           relations: ['reporter', 'resource', 'reportedMember']
         });
@@ -139,45 +139,45 @@ describe('ReportsService', () => {
         expect(result.category).toBe(ReportCategory.INAPPROPRIATE);
         expect(result.status).toBe('pending');
         expect(result.reporter).toBeDefined();
-        expect(result.reporter.uuidMember).toBe(mockReporter.uuidMember);
+        expect(result.reporter.idMember).toBe(mockReporter.idMember);
         expect(result.resource).toBeDefined();
         if (result.resource) {
-          expect(result.resource.uuidResource).toBe(mockResource.uuidResource);
+          expect(result.resource.idResource).toBe(mockResource.idResource);
         }
       });
 
-      it('should throw BadRequestException when creating resource report without uuidResource', async () => {
+      it('should throw BadRequestException when creating resource report without idResource', async () => {
         // Arrange
         const createReportDto: CreateReportDto = {
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
-          uuidReporter: '123e4567-e89b-12d3-a456-426614174000',
+          idReporter: '123e4567-e89b-12d3-a456-426614174000',
         };
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new BadRequestException('UUID de la ressource requis pour un signalement de ressource')
+          new BadRequestException('id de la ressource requis pour un signalement de ressource')
         );
         expect(mockMembersRepository.findOne).not.toHaveBeenCalled();
         expect(mockResourcesRepository.findOne).not.toHaveBeenCalled();
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
       });
 
-      it('should throw BadRequestException when creating resource report with uuidReportedMember', async () => {
+      it('should throw BadRequestException when creating resource report with idReportedMember', async () => {
         // Arrange
         const createReportDto: CreateReportDto = {
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
-          uuidReporter: '123e4567-e89b-12d3-a456-426614174000',
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
-          uuidReportedMember: '123e4567-e89b-12d3-a456-426614174002',
+          idReporter: '123e4567-e89b-12d3-a456-426614174000',
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
+          idReportedMember: '123e4567-e89b-12d3-a456-426614174002',
         };
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new BadRequestException('UUID du membre signalé non autorisé pour un signalement de ressource')
+          new BadRequestException('id du membre signalé non autorisé pour un signalement de ressource')
         );
         expect(mockMembersRepository.findOne).not.toHaveBeenCalled();
         expect(mockResourcesRepository.findOne).not.toHaveBeenCalled();
@@ -190,18 +190,18 @@ describe('ReportsService', () => {
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
-          uuidReporter: '123e4567-e89b-12d3-a456-426614174000',
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+          idReporter: '123e4567-e89b-12d3-a456-426614174000',
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
         };
 
         mockMembersRepository.findOne.mockResolvedValue(null);
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new NotFoundException(`Reporter with UUID ${createReportDto.uuidReporter} not found`)
+          new NotFoundException(`Reporter with id ${createReportDto.idReporter} not found`)
         );
         expect(mockMembersRepository.findOne).toHaveBeenCalledWith({
-          where: { uuidMember: createReportDto.uuidReporter }
+          where: { idMember: createReportDto.idReporter }
         });
         expect(mockResourcesRepository.findOne).not.toHaveBeenCalled();
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
@@ -210,7 +210,7 @@ describe('ReportsService', () => {
       it('should throw NotFoundException when resource does not exist', async () => {
         // Arrange
         const mockReporter = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           guildUsername: 'reporter',
           status: 'active',
         };
@@ -219,8 +219,8 @@ describe('ReportsService', () => {
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
-          uuidReporter: mockReporter.uuidMember,
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+          idReporter: mockReporter.idMember,
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
         };
 
         mockMembersRepository.findOne.mockResolvedValue(mockReporter);
@@ -228,13 +228,13 @@ describe('ReportsService', () => {
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new NotFoundException(`Resource with UUID ${createReportDto.uuidResource} not found`)
+          new NotFoundException(`Resource with id ${createReportDto.idResource} not found`)
         );
         expect(mockMembersRepository.findOne).toHaveBeenCalledWith({
-          where: { uuidMember: createReportDto.uuidReporter }
+          where: { idMember: createReportDto.idReporter }
         });
         expect(mockResourcesRepository.findOne).toHaveBeenCalledWith({
-          where: { uuidResource: createReportDto.uuidResource }
+          where: { idResource: createReportDto.idResource }
         });
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
       });
@@ -242,19 +242,19 @@ describe('ReportsService', () => {
       it('should throw ConflictException when report already exists', async () => {
         // Arrange
         const mockReporter = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           guildUsername: 'reporter',
           status: 'active',
         };
 
         const mockResource = {
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
           title: 'Reported Resource',
           status: 'active',
         };
 
         const existingReport = {
-          uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+          idReport: '123e4567-e89b-12d3-a456-426614174002',
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Existing report',
@@ -267,8 +267,8 @@ describe('ReportsService', () => {
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
-          uuidReporter: mockReporter.uuidMember,
-          uuidResource: mockResource.uuidResource,
+          idReporter: mockReporter.idMember,
+          idResource: mockResource.idResource,
         };
 
         mockMembersRepository.findOne.mockResolvedValue(mockReporter);
@@ -278,7 +278,7 @@ describe('ReportsService', () => {
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
           new ConflictException(
-            `Un signalement existe déjà pour cet élément par ce membre (UUID: ${existingReport.uuidReport})`
+            `Un signalement existe déjà pour cet élément par ce membre (id: ${existingReport.idReport})`
           )
         );
         expect(mockMembersRepository.findOne).toHaveBeenCalled();
@@ -291,13 +291,13 @@ describe('ReportsService', () => {
       it('should successfully create a member report', async () => {
         // Arrange
         const mockReporter = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           guildUsername: 'reporter',
           status: 'active',
         };
 
         const mockReportedMember = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
           guildUsername: 'reported',
           status: 'active',
         };
@@ -306,12 +306,12 @@ describe('ReportsService', () => {
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
-          uuidReporter: mockReporter.uuidMember,
-          uuidReportedMember: mockReportedMember.uuidMember,
+          idReporter: mockReporter.idMember,
+          idReportedMember: mockReportedMember.idMember,
         };
 
         const mockReport = {
-          uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+          idReport: '123e4567-e89b-12d3-a456-426614174002',
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
@@ -349,15 +349,15 @@ describe('ReportsService', () => {
 
         // Assert
         expect(mockMembersRepository.findOne).toHaveBeenNthCalledWith(1, {
-          where: { uuidMember: mockReporter.uuidMember }
+          where: { idMember: mockReporter.idMember }
         });
         expect(mockMembersRepository.findOne).toHaveBeenNthCalledWith(2, {
-          where: { uuidMember: mockReportedMember.uuidMember }
+          where: { idMember: mockReportedMember.idMember }
         });
         expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
           where: {
-            reporter: { uuidMember: mockReporter.uuidMember },
-            reportedMember: { uuidMember: mockReportedMember.uuidMember }
+            reporter: { idMember: mockReporter.idMember },
+            reportedMember: { idMember: mockReportedMember.idMember }
           },
           relations: ['reporter', 'resource', 'reportedMember']
         });
@@ -367,44 +367,44 @@ describe('ReportsService', () => {
         expect(result.category).toBe(ReportCategory.HARASSMENT);
         expect(result.status).toBe('pending');
         expect(result.reporter).toBeDefined();
-        expect(result.reporter.uuidMember).toBe(mockReporter.uuidMember);
+        expect(result.reporter.idMember).toBe(mockReporter.idMember);
         expect(result.reportedMember).toBeDefined();
         if (result.reportedMember) {
-          expect(result.reportedMember.uuidMember).toBe(mockReportedMember.uuidMember);
+          expect(result.reportedMember.idMember).toBe(mockReportedMember.idMember);
         }
       });
 
-      it('should throw BadRequestException when creating member report without uuidReportedMember', async () => {
+      it('should throw BadRequestException when creating member report without idReportedMember', async () => {
         // Arrange
         const createReportDto: CreateReportDto = {
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
-          uuidReporter: '123e4567-e89b-12d3-a456-426614174000',
+          idReporter: '123e4567-e89b-12d3-a456-426614174000',
         };
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new BadRequestException('UUID du membre signalé requis pour un signalement de membre')
+          new BadRequestException('id du membre signalé requis pour un signalement de membre')
         );
         expect(mockMembersRepository.findOne).not.toHaveBeenCalled();
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
       });
 
-      it('should throw BadRequestException when creating member report with uuidResource', async () => {
+      it('should throw BadRequestException when creating member report with idResource', async () => {
         // Arrange
         const createReportDto: CreateReportDto = {
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
-          uuidReporter: '123e4567-e89b-12d3-a456-426614174000',
-          uuidReportedMember: '123e4567-e89b-12d3-a456-426614174001',
-          uuidResource: '123e4567-e89b-12d3-a456-426614174002',
+          idReporter: '123e4567-e89b-12d3-a456-426614174000',
+          idReportedMember: '123e4567-e89b-12d3-a456-426614174001',
+          idResource: '123e4567-e89b-12d3-a456-426614174002',
         };
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new BadRequestException('UUID de la ressource non autorisé pour un signalement de membre')
+          new BadRequestException('id de la ressource non autorisé pour un signalement de membre')
         );
         expect(mockMembersRepository.findOne).not.toHaveBeenCalled();
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
@@ -416,18 +416,18 @@ describe('ReportsService', () => {
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
-          uuidReporter: '123e4567-e89b-12d3-a456-426614174000',
-          uuidReportedMember: '123e4567-e89b-12d3-a456-426614174001',
+          idReporter: '123e4567-e89b-12d3-a456-426614174000',
+          idReportedMember: '123e4567-e89b-12d3-a456-426614174001',
         };
 
         mockMembersRepository.findOne.mockResolvedValue(null);
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new NotFoundException(`Reporter with UUID ${createReportDto.uuidReporter} not found`)
+          new NotFoundException(`Reporter with id ${createReportDto.idReporter} not found`)
         );
         expect(mockMembersRepository.findOne).toHaveBeenCalledWith({
-          where: { uuidMember: createReportDto.uuidReporter }
+          where: { idMember: createReportDto.idReporter }
         });
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
       });
@@ -435,7 +435,7 @@ describe('ReportsService', () => {
       it('should throw NotFoundException when reported member does not exist', async () => {
         // Arrange
         const mockReporter = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           guildUsername: 'reporter',
           status: 'active',
         };
@@ -444,8 +444,8 @@ describe('ReportsService', () => {
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
-          uuidReporter: mockReporter.uuidMember,
-          uuidReportedMember: '123e4567-e89b-12d3-a456-426614174001',
+          idReporter: mockReporter.idMember,
+          idReportedMember: '123e4567-e89b-12d3-a456-426614174001',
         };
 
         mockMembersRepository.findOne
@@ -454,13 +454,13 @@ describe('ReportsService', () => {
 
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
-          new NotFoundException(`Member with UUID ${createReportDto.uuidReportedMember} not found`)
+          new NotFoundException(`Member with id ${createReportDto.idReportedMember} not found`)
         );
         expect(mockMembersRepository.findOne).toHaveBeenNthCalledWith(1, {
-          where: { uuidMember: createReportDto.uuidReporter }
+          where: { idMember: createReportDto.idReporter }
         });
         expect(mockMembersRepository.findOne).toHaveBeenNthCalledWith(2, {
-          where: { uuidMember: createReportDto.uuidReportedMember }
+          where: { idMember: createReportDto.idReportedMember }
         });
         expect(mockReportsRepository.save).not.toHaveBeenCalled();
       });
@@ -468,19 +468,19 @@ describe('ReportsService', () => {
       it('should throw ConflictException when report already exists', async () => {
         // Arrange
         const mockReporter = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           guildUsername: 'reporter',
           status: 'active',
         };
 
         const mockReportedMember = {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
           guildUsername: 'reported',
           status: 'active',
         };
 
         const existingReport = {
-          uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+          idReport: '123e4567-e89b-12d3-a456-426614174002',
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Existing report',
@@ -493,8 +493,8 @@ describe('ReportsService', () => {
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Test reason',
-          uuidReporter: mockReporter.uuidMember,
-          uuidReportedMember: mockReportedMember.uuidMember,
+          idReporter: mockReporter.idMember,
+          idReportedMember: mockReportedMember.idMember,
         };
 
         mockMembersRepository.findOne
@@ -505,7 +505,7 @@ describe('ReportsService', () => {
         // Act & Assert
         await expect(service.create(createReportDto)).rejects.toThrow(
           new ConflictException(
-            `Un signalement existe déjà pour cet élément par ce membre (UUID: ${existingReport.uuidReport})`
+            `Un signalement existe déjà pour cet élément par ce membre (id: ${existingReport.idReport})`
           )
         );
         expect(mockMembersRepository.findOne).toHaveBeenCalled();
@@ -518,26 +518,26 @@ describe('ReportsService', () => {
     it('should return all reports with their relations', async () => {
       // Arrange
       const mockReporter = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         guildUsername: 'reporter',
         status: 'active',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Reported Resource',
         status: 'active',
       };
 
       const mockReportedMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174002',
+        idMember: '123e4567-e89b-12d3-a456-426614174002',
         guildUsername: 'reported',
         status: 'active',
       };
 
       const mockReports = [
         {
-          uuidReport: '123e4567-e89b-12d3-a456-426614174003',
+          idReport: '123e4567-e89b-12d3-a456-426614174003',
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Resource report',
@@ -548,7 +548,7 @@ describe('ReportsService', () => {
           updatedAt: new Date('2024-03-15'),
         },
         {
-          uuidReport: '123e4567-e89b-12d3-a456-426614174004',
+          idReport: '123e4567-e89b-12d3-a456-426614174004',
           type: ReportType.MEMBER,
           category: ReportCategory.HARASSMENT,
           reason: 'Member report',
@@ -575,20 +575,20 @@ describe('ReportsService', () => {
       // Vérifier le signalement de ressource
       expect(result[0].type).toBe(ReportType.RESOURCE);
       expect(result[0].reporter).toBeDefined();
-      expect(result[0].reporter.uuidMember).toBe(mockReporter.uuidMember);
+      expect(result[0].reporter.idMember).toBe(mockReporter.idMember);
       expect(result[0].resource).toBeDefined();
       if (result[0].resource) {
-        expect(result[0].resource.uuidResource).toBe(mockResource.uuidResource);
+        expect(result[0].resource.idResource).toBe(mockResource.idResource);
       }
       expect(result[0].reportedMember).toBeUndefined();
 
       // Vérifier le signalement de membre
       expect(result[1].type).toBe(ReportType.MEMBER);
       expect(result[1].reporter).toBeDefined();
-      expect(result[1].reporter.uuidMember).toBe(mockReporter.uuidMember);
+      expect(result[1].reporter.idMember).toBe(mockReporter.idMember);
       expect(result[1].reportedMember).toBeDefined();
       if (result[1].reportedMember) {
-        expect(result[1].reportedMember.uuidMember).toBe(mockReportedMember.uuidMember);
+        expect(result[1].reportedMember.idMember).toBe(mockReportedMember.idMember);
       }
       expect(result[1].resource).toBeUndefined();
     });
@@ -614,19 +614,19 @@ describe('ReportsService', () => {
     it('should return a report with all its relations', async () => {
       // Arrange
       const mockReporter = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         guildUsername: 'reporter',
         status: 'active',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Reported Resource',
         status: 'active',
       };
 
       const mockReport = {
-        uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+        idReport: '123e4567-e89b-12d3-a456-426614174002',
         type: ReportType.RESOURCE,
         category: ReportCategory.INAPPROPRIATE,
         reason: 'Test reason',
@@ -640,35 +640,35 @@ describe('ReportsService', () => {
       mockReportsRepository.findOne.mockResolvedValue(mockReport);
 
       // Act
-      const result = await service.findOne(mockReport.uuidReport);
+      const result = await service.findOne(mockReport.idReport);
 
       // Assert
       expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidReport: mockReport.uuidReport },
+        where: { idReport: mockReport.idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
       expect(result).toBeDefined();
-      expect(result.uuidReport).toBe(mockReport.uuidReport);
+      expect(result.idReport).toBe(mockReport.idReport);
       expect(result.type).toBe(ReportType.RESOURCE);
       expect(result.reporter).toBeDefined();
-      expect(result.reporter.uuidMember).toBe(mockReporter.uuidMember);
+      expect(result.reporter.idMember).toBe(mockReporter.idMember);
       expect(result.resource).toBeDefined();
       if (result.resource) {
-        expect(result.resource.uuidResource).toBe(mockResource.uuidResource);
+        expect(result.resource.idResource).toBe(mockResource.idResource);
       }
     });
 
     it('should throw NotFoundException when report does not exist', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const idReport = '123e4567-e89b-12d3-a456-426614174000';
       mockReportsRepository.findOne.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(service.findOne(uuid)).rejects.toThrow(
-        new NotFoundException(`Report with UUID ${uuid} not found`)
+      await expect(service.findOne(idReport)).rejects.toThrow(
+        new NotFoundException(`Report with id ${idReport} not found`)
       );
       expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidReport: uuid },
+        where: { idReport: idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
     });
@@ -678,19 +678,19 @@ describe('ReportsService', () => {
     it('should update a report with modifiable fields only', async () => {
       // Arrange
       const mockReporter = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'reporter',
         status: 'active',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Test Resource',
         status: 'active',
       };
 
       const existingReport = {
-        uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+        idReport: '123e4567-e89b-12d3-a456-426614174002',
         type: ReportType.RESOURCE,
         category: ReportCategory.INAPPROPRIATE,
         reason: 'Test reason',
@@ -719,11 +719,11 @@ describe('ReportsService', () => {
       mockReportsRepository.save.mockResolvedValue(updatedReport);
 
       // Act
-      const result = await service.update(existingReport.uuidReport, updateReportDto);
+      const result = await service.update(existingReport.idReport, updateReportDto);
 
       // Assert
       expect(mockReportsRepository.findOne).toHaveBeenNthCalledWith(1, {
-        where: { uuidReport: existingReport.uuidReport },
+        where: { idReport: existingReport.idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
 
@@ -733,7 +733,7 @@ describe('ReportsService', () => {
       });
 
       expect(mockReportsRepository.findOne).toHaveBeenNthCalledWith(2, {
-        where: { uuidReport: updatedReport.uuidReport },
+        where: { idReport: updatedReport.idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
 
@@ -744,13 +744,13 @@ describe('ReportsService', () => {
 
       // Verify immutable fields remain unchanged
       expect(result.type).toBe(existingReport.type);
-      expect(result.reporter.uuidMember).toBe(existingReport.reporter.uuidMember);
-      expect(result.resource?.uuidResource).toBe(existingReport.resource.uuidResource);
+      expect(result.reporter.idMember).toBe(existingReport.reporter.idMember);
+      expect(result.resource?.idResource).toBe(existingReport.resource.idResource);
     });
 
     it('should throw NotFoundException when report does not exist', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idReport = '123e4567-e89b-12d3-a456-426614174001';
       const updateReportDto = {
         category: ReportCategory.HARASSMENT,
         reason: 'Updated reason',
@@ -760,12 +760,12 @@ describe('ReportsService', () => {
       mockReportsRepository.findOne.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(service.update(uuid, updateReportDto)).rejects.toThrow(
-        new NotFoundException(`Report with UUID ${uuid} not found`)
+      await expect(service.update(idReport, updateReportDto)).rejects.toThrow(
+        new NotFoundException(`Report with id ${idReport} not found`)
       );
 
       expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidReport: uuid },
+        where: { idReport: idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
       expect(mockReportsRepository.save).not.toHaveBeenCalled();
@@ -776,19 +776,19 @@ describe('ReportsService', () => {
     it('should successfully remove a report when user is the creator', async () => {
       // Arrange
       const mockReporter = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         guildUsername: 'testuser',
         communityRole: 'Member',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Test Resource',
         status: 'active',
       };
 
       const existingReport = {
-        uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+        idReport: '123e4567-e89b-12d3-a456-426614174002',
         type: ReportType.RESOURCE,
         category: ReportCategory.INAPPROPRIATE,
         reason: 'Test reason',
@@ -812,11 +812,11 @@ describe('ReportsService', () => {
       mockReportsRepository.remove.mockResolvedValue(undefined);
 
       // Act
-      await service.remove(existingReport.uuidReport, mockReporter.uuidMember);
+      await service.remove(existingReport.idReport, mockReporter.idMember);
 
       // Assert
       expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidReport: existingReport.uuidReport },
+        where: { idReport: existingReport.idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
       expect(mockReportsRepository.remove).toHaveBeenCalledWith({
@@ -828,17 +828,17 @@ describe('ReportsService', () => {
 
     it('should throw NotFoundException when report does not exist', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const idReport = '123e4567-e89b-12d3-a456-426614174000';
       const currentUserId = '123e4567-e89b-12d3-a456-426614174001';
 
       mockReportsRepository.findOne.mockResolvedValue(null);
 
       // Act & Assert
-      await expect(service.remove(uuid, currentUserId)).rejects.toThrow(
-        new NotFoundException(`Report with UUID ${uuid} not found`)
+      await expect(service.remove(idReport, currentUserId)).rejects.toThrow(
+        new NotFoundException(`Report with id ${idReport} not found`)
       );
       expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidReport: uuid },
+        where: { idReport: idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
       expect(mockReportsRepository.remove).not.toHaveBeenCalled();
@@ -847,19 +847,19 @@ describe('ReportsService', () => {
     it('should throw ForbiddenException when user is not the creator', async () => {
       // Arrange
       const mockReporter = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         guildUsername: 'testuser',
         communityRole: 'Member',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Test Resource',
         status: 'active',
       };
 
       const existingReport = {
-        uuidReport: '123e4567-e89b-12d3-a456-426614174002',
+        idReport: '123e4567-e89b-12d3-a456-426614174002',
         type: ReportType.RESOURCE,
         category: ReportCategory.INAPPROPRIATE,
         reason: 'Test reason',
@@ -877,11 +877,11 @@ describe('ReportsService', () => {
       });
 
       // Act & Assert
-      await expect(service.remove(existingReport.uuidReport, currentUserId)).rejects.toThrow(
+      await expect(service.remove(existingReport.idReport, currentUserId)).rejects.toThrow(
         new ForbiddenException('Vous ne pouvez supprimer que vos propres signalements')
       );
       expect(mockReportsRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidReport: existingReport.uuidReport },
+        where: { idReport: existingReport.idReport },
         relations: ['reporter', 'resource', 'reportedMember']
       });
       expect(mockReportsRepository.remove).not.toHaveBeenCalled();

--- a/src/reports/reports.service.ts
+++ b/src/reports/reports.service.ts
@@ -22,25 +22,25 @@ export class ReportsService {
 
   async create(createReportDto: CreateReportDto): Promise<ReportResponseDto> {
     // Validation conditionnelle selon le type de signalement
-    if (createReportDto.type === ReportType.RESOURCE && !createReportDto.uuidResource) {
-      throw new BadRequestException('UUID de la ressource requis pour un signalement de ressource');
+    if (createReportDto.type === ReportType.RESOURCE && !createReportDto.idResource) {
+      throw new BadRequestException('id de la ressource requis pour un signalement de ressource');
     }
-    if (createReportDto.type === ReportType.MEMBER && !createReportDto.uuidReportedMember) {
-      throw new BadRequestException('UUID du membre signalé requis pour un signalement de membre');
+    if (createReportDto.type === ReportType.MEMBER && !createReportDto.idReportedMember) {
+      throw new BadRequestException('id du membre signalé requis pour un signalement de membre');
     }
-    if (createReportDto.type === ReportType.RESOURCE && createReportDto.uuidReportedMember) {
-      throw new BadRequestException('UUID du membre signalé non autorisé pour un signalement de ressource');
+    if (createReportDto.type === ReportType.RESOURCE && createReportDto.idReportedMember) {
+      throw new BadRequestException('id du membre signalé non autorisé pour un signalement de ressource');
     }
-    if (createReportDto.type === ReportType.MEMBER && createReportDto.uuidResource) {
-      throw new BadRequestException('UUID de la ressource non autorisé pour un signalement de membre');
+    if (createReportDto.type === ReportType.MEMBER && createReportDto.idResource) {
+      throw new BadRequestException('id de la ressource non autorisé pour un signalement de membre');
     }
 
     // Vérifier que le reporter existe
     const reporter = await this.membersRepository.findOne({
-      where: { uuidMember: createReportDto.uuidReporter }
+      where: { idMember: createReportDto.idReporter }
     });
     if (!reporter) {
-      throw new NotFoundException(`Reporter with UUID ${createReportDto.uuidReporter} not found`);
+      throw new NotFoundException(`Reporter with id ${createReportDto.idReporter} not found`);
     }
 
     // Vérifier l'élément reporté selon le type
@@ -49,33 +49,33 @@ export class ReportsService {
 
     if (createReportDto.type === ReportType.RESOURCE) {
       resource = await this.resourcesRepository.findOne({
-        where: { uuidResource: createReportDto.uuidResource }
+        where: { idResource: createReportDto.idResource }
       });
       if (!resource) {
-        throw new NotFoundException(`Resource with UUID ${createReportDto.uuidResource} not found`);
+        throw new NotFoundException(`Resource with id ${createReportDto.idResource} not found`);
       }
     } else if (createReportDto.type === ReportType.MEMBER) {
       reportedMember = await this.membersRepository.findOne({
-        where: { uuidMember: createReportDto.uuidReportedMember }
+        where: { idMember: createReportDto.idReportedMember }
       });
       if (!reportedMember) {
-        throw new NotFoundException(`Member with UUID ${createReportDto.uuidReportedMember} not found`);
+        throw new NotFoundException(`Member with id ${createReportDto.idReportedMember} not found`);
       }
     }
 
     // Vérifier si un signalement similaire existe déjà
     const existingReport = await this.reportsRepository.findOne({
       where: {
-        reporter: { uuidMember: reporter.uuidMember },
-        ...(resource && { resource: { uuidResource: resource.uuidResource } }),
-        ...(reportedMember && { reportedMember: { uuidMember: reportedMember.uuidMember } })
+        reporter: { idMember: reporter.idMember },
+        ...(resource && { resource: { idResource: resource.idResource } }),
+        ...(reportedMember && { reportedMember: { idMember: reportedMember.idMember } })
       },
       relations: ['reporter', 'resource', 'reportedMember']
     });
 
     if (existingReport) {
       throw new ConflictException(
-        `Un signalement existe déjà pour cet élément par ce membre (UUID: ${existingReport.uuidReport})`
+        `Un signalement existe déjà pour cet élément par ce membre (id: ${existingReport.idReport})`
       );
     }
 
@@ -93,7 +93,7 @@ export class ReportsService {
     
     // Récupérer le rapport avec toutes ses relations
     const reportWithRelations = await this.reportsRepository.findOne({
-      where: { uuidReport: savedReport.uuidReport },
+      where: { idReport: savedReport.idReport },
       relations: ['reporter', 'resource', 'reportedMember']
     });
 
@@ -110,28 +110,28 @@ export class ReportsService {
     );
   }
 
-  async findOne(uuidReport: string): Promise<ReportResponseDto> {
+  async findOne(idReport: string): Promise<ReportResponseDto> {
     const report = await this.reportsRepository.findOne({
-      where: { uuidReport },
+      where: { idReport },
       relations: ['reporter', 'resource', 'reportedMember']
     });
     
     if (!report) {
-      throw new NotFoundException(`Report with UUID ${uuidReport} not found`);
+      throw new NotFoundException(`Report with id ${idReport} not found`);
     }
     
     return plainToInstance(ReportResponseDto, report, { excludeExtraneousValues: true });
   }
 
-  async update(uuid: string, updateReportDto: UpdateReportDto): Promise<ReportResponseDto> {
+  async update(idReport: string, updateReportDto: UpdateReportDto): Promise<ReportResponseDto> {
     // Vérifier que le signalement existe
     const report = await this.reportsRepository.findOne({
-      where: { uuidReport: uuid },
+      where: { idReport: idReport },
       relations: ['reporter', 'resource', 'reportedMember']
     });
 
     if (!report) {
-      throw new NotFoundException(`Report with UUID ${uuid} not found`);
+      throw new NotFoundException(`Report with id ${idReport} not found`);
     }
 
     // Mettre à jour le signalement
@@ -142,18 +142,18 @@ export class ReportsService {
 
     // Récupérer le signalement mis à jour avec toutes ses relations
     const reportWithRelations = await this.reportsRepository.findOne({
-      where: { uuidReport: updatedReport.uuidReport },
+      where: { idReport: updatedReport.idReport },
       relations: ['reporter', 'resource', 'reportedMember']
     });
 
     return plainToInstance(ReportResponseDto, reportWithRelations, { excludeExtraneousValues: true });
   }
 
-  async remove(uuid: string, currentUserId: string): Promise<void> {
-    const reportDto = await this.findOne(uuid);
+  async remove(idReport: string, currentUserId: string): Promise<void> {
+    const reportDto = await this.findOne(idReport);
     
     // Vérifier si l'utilisateur est le créateur du signalement
-    if (reportDto.reporter.uuidMember !== currentUserId) {
+    if (reportDto.reporter.idMember !== currentUserId) {
       throw new ForbiddenException(
         'Vous ne pouvez supprimer que vos propres signalements'
       );
@@ -161,12 +161,12 @@ export class ReportsService {
 
     // Récupérer l'entité Report avant de la supprimer
     const report = await this.reportsRepository.findOne({
-      where: { uuidReport: uuid },
+      where: { idReport: idReport },
       relations: ['reporter', 'resource', 'reportedMember']
     });
 
     if (!report) {
-      throw new NotFoundException(`Report with UUID ${uuid} not found`);
+      throw new NotFoundException(`Report with id ${idReport} not found`);
     }
 
     await this.reportsRepository.remove(report);

--- a/src/resources/dto/create-resource.dto.spec.ts
+++ b/src/resources/dto/create-resource.dto.spec.ts
@@ -10,7 +10,7 @@ describe('CreateResourceDto', () => {
     dto.description = 'Test Description';
     dto.content = 'Test Content';
     dto.status = 'active';
-    dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+    dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
     // Act
     const errors = await validate(dto);
@@ -27,7 +27,7 @@ describe('CreateResourceDto', () => {
       dto.description = 'Test Description';
       dto.content = 'Test Content';
       dto.status = 'active';
-      dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+      dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
       // Act
       const errors = await validate(dto);
@@ -45,7 +45,7 @@ describe('CreateResourceDto', () => {
       dto.description = 'Test Description';
       dto.content = 'Test Content';
       dto.status = 'active';
-      dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+      dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
       // Act
       const errors = await validate(dto);
@@ -65,7 +65,7 @@ describe('CreateResourceDto', () => {
       dto.description = '';
       dto.content = 'Test Content';
       dto.status = 'active';
-      dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+      dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
       // Act
       const errors = await validate(dto);
@@ -85,7 +85,7 @@ describe('CreateResourceDto', () => {
       dto.description = 'Test Description';
       dto.content = '';
       dto.status = 'active';
-      dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+      dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
       // Act
       const errors = await validate(dto);
@@ -105,7 +105,7 @@ describe('CreateResourceDto', () => {
       dto.description = 'Test Description';
       dto.content = 'Test Content';
       dto.status = 'invalid_status';
-      dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+      dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
       // Act
       const errors = await validate(dto);
@@ -126,7 +126,7 @@ describe('CreateResourceDto', () => {
           dto.description = 'Test Description';
           dto.content = 'Test Content';
           dto.status = status;
-          dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+          dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
 
           // Act
           return validate(dto);
@@ -140,22 +140,22 @@ describe('CreateResourceDto', () => {
     });
   });
 
-  describe('uuidMember validation', () => {
-    it('should fail when uuidMember is not a valid UUID', async () => {
+  describe('idMember validation', () => {
+    it('should fail when idMember is not a valid UUID', async () => {
       // Arrange
       const dto = new CreateResourceDto();
       dto.title = 'Test Resource';
       dto.description = 'Test Description';
       dto.content = 'Test Content';
       dto.status = 'active';
-      dto.uuidMember = 'not-a-uuid';
+      dto.idMember = 'not-a-uuid';
 
       // Act
       const errors = await validate(dto);
 
       // Assert
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].property).toBe('uuidMember');
+      expect(errors[0].property).toBe('idMember');
       expect(errors[0].constraints).toHaveProperty('isUuid');
     });
   });

--- a/src/resources/dto/create-resource.dto.ts
+++ b/src/resources/dto/create-resource.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsString, MaxLength, IsEnum, IsNotEmpty } from 'class-validator';
-import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from '../../utils/pickable-intern-id-fields';
 import { PickableDtoFields } from '../../utils/pickable-dto-fields';
 
-export class CreateResourceDto extends PickType(PickableInternUUIDFields, [
-  'uuidMember' // Pour le créateur
+export class CreateResourceDto extends PickType(PickableInternIdFields, [
+  'idMember' // Pour le créateur
 ]) {
   @ApiProperty({
     description: 'Le titre de la ressource',

--- a/src/resources/dto/responses/resource.response.dto.spec.ts
+++ b/src/resources/dto/responses/resource.response.dto.spec.ts
@@ -7,22 +7,22 @@ describe('Resource Response DTOs', () => {
   describe('ResourceCreatorResponseDto', () => {
     it('should expose only allowed fields', () => {
       const plainObject = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         guildUsername: 'TestUser',
         communityRole: 'Member',
         createdAt: new Date(),
         updatedAt: new Date(),
         level: 1,
         status: 'active',
-        uuidDiscord: 'discord123',
-        uuidGuild: 'guild123',
+        idDiscord: 'discord123',
+        idGuild: 'guild123',
         xp: '100'
       };
 
       const transformed = plainToInstance(ResourceCreatorResponseDto, plainObject);
 
       // Should expose these fields
-      expect(transformed.uuidMember).toBe(plainObject.uuidMember);
+      expect(transformed.idMember).toBe(plainObject.idMember);
       expect(transformed.guildUsername).toBe(plainObject.guildUsername);
       expect(transformed.communityRole).toBe(plainObject.communityRole);
 
@@ -31,8 +31,8 @@ describe('Resource Response DTOs', () => {
       expect(transformed['updatedAt']).toBeUndefined();
       expect(transformed['level']).toBeUndefined();
       expect(transformed['status']).toBeUndefined();
-      expect(transformed['uuidDiscord']).toBeUndefined();
-      expect(transformed['uuidGuild']).toBeUndefined();
+      expect(transformed['idDiscord']).toBeUndefined();
+      expect(transformed['idGuild']).toBeUndefined();
       expect(transformed['xp']).toBeUndefined();
     });
   });
@@ -40,14 +40,14 @@ describe('Resource Response DTOs', () => {
   describe('ResourceReportResponseDto', () => {
     it('should transform and expose all fields correctly', () => {
       const plainObject = {
-        uuid_report: '123e4567-e89b-12d3-a456-426614174000',
+        id_report: '123e4567-e89b-12d3-a456-426614174000',
         type: ReportType.RESOURCE,
         category: ReportCategory.INAPPROPRIATE,
         reason: 'Test reason',
         status: 'pending',
         created_at: '2024-02-25T12:00:00Z',
         reporter: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
           guildUsername: 'Reporter',
           communityRole: 'Member'
         }
@@ -55,26 +55,26 @@ describe('Resource Response DTOs', () => {
 
       const transformed = plainToInstance(ResourceReportResponseDto, plainObject, { enableImplicitConversion: true });
 
-      expect(transformed.uuidReport).toBe(plainObject.uuid_report);
+      expect(transformed.idReport).toBe(plainObject.id_report);
       expect(transformed.type).toBe(plainObject.type);
       expect(transformed.category).toBe(plainObject.category);
       expect(transformed.reason).toBe(plainObject.reason);
       expect(transformed.status).toBe(plainObject.status);
       expect(transformed.createdAt).toBeInstanceOf(Date);
       expect(transformed.reporter).toBeInstanceOf(ResourceCreatorResponseDto);
-      expect(transformed.reporter.uuidMember).toBe(plainObject.reporter.uuidMember);
+      expect(transformed.reporter.idMember).toBe(plainObject.reporter.idMember);
     });
   });
 
   describe('ResourceVoteResponseDto', () => {
     it('should transform and expose all fields correctly', () => {
       const plainObject = {
-        uuidVote: '123e4567-e89b-12d3-a456-426614174000',
+        idVote: '123e4567-e89b-12d3-a456-426614174000',
         voteType: VoteType.UPVOTE,
         createdAt: '2024-02-25T12:00:00Z',
         isActive: true,
         member: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
           guildUsername: 'Voter',
           communityRole: 'Member'
         }
@@ -82,34 +82,34 @@ describe('Resource Response DTOs', () => {
 
       const transformed = plainToInstance(ResourceVoteResponseDto, plainObject, { enableImplicitConversion: true });
 
-      expect(transformed.uuidVote).toBe(plainObject.uuidVote);
+      expect(transformed.idVote).toBe(plainObject.idVote);
       expect(transformed.voteType).toBe(plainObject.voteType);
       expect(transformed.createdAt).toBeInstanceOf(Date);
       expect(transformed.isActive).toBe(plainObject.isActive);
       expect(transformed.member).toBeInstanceOf(ResourceCreatorResponseDto);
-      expect(transformed.member.uuidMember).toBe(plainObject.member.uuidMember);
+      expect(transformed.member.idMember).toBe(plainObject.member.idMember);
     });
   });
 
   describe('ResourceCommentResponseDto', () => {
     it('should transform and expose all fields correctly', () => {
       const plainObject = {
-        uuidComment: '123e4567-e89b-12d3-a456-426614174000',
+        idComment: '123e4567-e89b-12d3-a456-426614174000',
         content: 'Test comment',
         status: 'active',
         createdAt: '2024-02-25T12:00:00Z',
         member: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
           guildUsername: 'Commenter',
           communityRole: 'Member'
         },
         votes: [{
-          uuidVote: '123e4567-e89b-12d3-a456-426614174002',
+          idVote: '123e4567-e89b-12d3-a456-426614174002',
           voteType: VoteType.UPVOTE,
           createdAt: '2024-02-25T12:00:00Z',
           isActive: true,
           member: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174003',
+            idMember: '123e4567-e89b-12d3-a456-426614174003',
             guildUsername: 'Voter',
             communityRole: 'Member'
           }
@@ -118,64 +118,64 @@ describe('Resource Response DTOs', () => {
 
       const transformed = plainToInstance(ResourceCommentResponseDto, plainObject, { enableImplicitConversion: true });
 
-      expect(transformed.uuidComment).toBe(plainObject.uuidComment);
+      expect(transformed.idComment).toBe(plainObject.idComment);
       expect(transformed.content).toBe(plainObject.content);
       expect(transformed.status).toBe(plainObject.status);
       expect(transformed.createdAt).toBeInstanceOf(Date);
       expect(transformed.member).toBeInstanceOf(ResourceCreatorResponseDto);
-      expect(transformed.member.uuidMember).toBe(plainObject.member.uuidMember);
+      expect(transformed.member.idMember).toBe(plainObject.member.idMember);
       expect(transformed.votes[0]).toBeInstanceOf(ResourceVoteResponseDto);
-      expect(transformed.votes[0].uuidVote).toBe(plainObject.votes[0].uuidVote);
+      expect(transformed.votes[0].idVote).toBe(plainObject.votes[0].idVote);
     });
   });
 
   describe('ResourceResponseDto', () => {
     it('should transform and expose all fields with nested relationships', () => {
       const plainObject = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174000',
+        idResource: '123e4567-e89b-12d3-a456-426614174000',
         title: 'Test Resource',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
-        creatorUuid: '123e4567-e89b-12d3-a456-426614174001',
+        idCreator: '123e4567-e89b-12d3-a456-426614174001',
         createdAt: '2024-02-25T12:00:00Z',
         updatedAt: '2024-02-25T12:00:00Z',
         creator: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
           guildUsername: 'Creator',
           communityRole: 'Member'
         },
         reports: [{
-          uuid_report: '123e4567-e89b-12d3-a456-426614174002',
+          id_report: '123e4567-e89b-12d3-a456-426614174002',
           type: ReportType.RESOURCE,
           category: ReportCategory.INAPPROPRIATE,
           reason: 'Test reason',
           status: 'pending',
           created_at: '2024-02-25T12:00:00Z',
           reporter: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174003',
+            idMember: '123e4567-e89b-12d3-a456-426614174003',
             guildUsername: 'Reporter',
             communityRole: 'Member'
           }
         }],
         votes: [{
-          uuidVote: '123e4567-e89b-12d3-a456-426614174004',
+          idVote: '123e4567-e89b-12d3-a456-426614174004',
           voteType: VoteType.UPVOTE,
           createdAt: '2024-02-25T12:00:00Z',
           isActive: true,
           member: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174005',
+            idMember: '123e4567-e89b-12d3-a456-426614174005',
             guildUsername: 'Voter',
             communityRole: 'Member'
           }
         }],
         comments: [{
-          uuidComment: '123e4567-e89b-12d3-a456-426614174006',
+          idComment: '123e4567-e89b-12d3-a456-426614174006',
           content: 'Test comment',
           status: 'active',
           createdAt: '2024-02-25T12:00:00Z',
           member: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174007',
+            idMember: '123e4567-e89b-12d3-a456-426614174007',
             guildUsername: 'Commenter',
             communityRole: 'Member'
           },
@@ -186,29 +186,29 @@ describe('Resource Response DTOs', () => {
       const transformed = plainToInstance(ResourceResponseDto, plainObject, { enableImplicitConversion: true });
 
       // Test basic fields
-      expect(transformed.uuidResource).toBe(plainObject.uuidResource);
+      expect(transformed.idResource).toBe(plainObject.idResource);
       expect(transformed.title).toBe(plainObject.title);
       expect(transformed.description).toBe(plainObject.description);
       expect(transformed.content).toBe(plainObject.content);
       expect(transformed.status).toBe(plainObject.status);
-      expect(transformed.creatorUuid).toBe(plainObject.creatorUuid);
+      expect(transformed.idCreator).toBe(plainObject.idCreator);
       expect(transformed.createdAt).toBeInstanceOf(Date);
       expect(transformed.updatedAt).toBeInstanceOf(Date);
 
       // Test nested relationships
       expect(transformed.creator).toBeInstanceOf(ResourceCreatorResponseDto);
-      expect(transformed.creator.uuidMember).toBe(plainObject.creator.uuidMember);
+      expect(transformed.creator.idMember).toBe(plainObject.creator.idMember);
 
       expect(transformed.reports[0]).toBeInstanceOf(ResourceReportResponseDto);
-      expect(transformed.reports[0].uuidReport).toBe(plainObject.reports[0].uuid_report);
+      expect(transformed.reports[0].idReport).toBe(plainObject.reports[0].id_report);
       expect(transformed.reports[0].reporter).toBeInstanceOf(ResourceCreatorResponseDto);
 
       expect(transformed.votes[0]).toBeInstanceOf(ResourceVoteResponseDto);
-      expect(transformed.votes[0].uuidVote).toBe(plainObject.votes[0].uuidVote);
+      expect(transformed.votes[0].idVote).toBe(plainObject.votes[0].idVote);
       expect(transformed.votes[0].member).toBeInstanceOf(ResourceCreatorResponseDto);
 
       expect(transformed.comments[0]).toBeInstanceOf(ResourceCommentResponseDto);
-      expect(transformed.comments[0].uuidComment).toBe(plainObject.comments[0].uuidComment);
+      expect(transformed.comments[0].idComment).toBe(plainObject.comments[0].idComment);
       expect(transformed.comments[0].member).toBeInstanceOf(ResourceCreatorResponseDto);
     });
   });

--- a/src/resources/dto/responses/resource.response.dto.ts
+++ b/src/resources/dto/responses/resource.response.dto.ts
@@ -9,7 +9,7 @@ export class ResourceCreatorResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidMember: string;
+  idMember: string;
 
   @ApiProperty({
     description: 'Nom d\'utilisateur sur le serveur',
@@ -39,10 +39,10 @@ export class ResourceCreatorResponseDto {
   status: string;
 
   @Exclude()
-  uuidDiscord: string;
+  idDiscord: string;
 
   @Exclude()
-  uuidGuild: string;
+  idGuild: string;
 
   @Exclude()
   xp: string;
@@ -53,8 +53,8 @@ export class ResourceReportResponseDto {
     description: 'UUID du signalement',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Expose({ name: 'uuid_report' })
-  uuidReport: string;
+  @Expose({ name: 'id_report' })
+  idReport: string;
 
   @ApiProperty({
     description: 'Type de signalement',
@@ -108,7 +108,7 @@ export class ResourceVoteResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidVote: string;
+  idVote: string;
 
   @ApiProperty({
     description: 'Type de vote',
@@ -147,7 +147,7 @@ export class ResourceCommentResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidComment: string;
+  idComment: string;
 
   @ApiProperty({
     description: 'Contenu du commentaire',
@@ -193,7 +193,7 @@ export class ResourceResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidResource: string;
+  idResource: string;
 
   @ApiProperty({
     description: 'Titre de la ressource',
@@ -228,7 +228,7 @@ export class ResourceResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  creatorUuid: string;
+  idCreator: string;
 
   @ApiProperty({
     description: 'Date de création',

--- a/src/resources/dto/update-resource.dto.ts
+++ b/src/resources/dto/update-resource.dto.ts
@@ -1,7 +1,7 @@
 import { OmitType, PartialType } from '@nestjs/swagger';
 import { CreateResourceDto } from './create-resource.dto';
 
-// On exclut uuidMember du DTO de mise à jour
+// On exclut idMember du DTO de mise à jour
 export class UpdateResourceDto extends PartialType(
-  OmitType(CreateResourceDto, ['uuidMember'] as const)
+  OmitType(CreateResourceDto, ['idMember'] as const)
 ) {} 

--- a/src/resources/entities/resource.entity.spec.ts
+++ b/src/resources/entities/resource.entity.spec.ts
@@ -10,12 +10,12 @@ describe('Resource Entity', () => {
 
   beforeEach(() => {
     resource = new Resource();
-    resource.uuidResource = '123e4567-e89b-12d3-a456-426614174000';
+    resource.idResource = '123e4567-e89b-12d3-a456-426614174000';
     resource.title = 'Test Resource';
     resource.description = 'Test Description';
     resource.content = 'Test Content';
     resource.status = 'active';
-    resource.creatorUuid = '123e4567-e89b-12d3-a456-426614174001';
+    resource.idCreator = '123e4567-e89b-12d3-a456-426614174001';
     resource.createdAt = new Date('2024-02-25T12:00:00Z');
     resource.updatedAt = new Date('2024-02-25T12:00:00Z');
   });
@@ -23,12 +23,12 @@ describe('Resource Entity', () => {
   describe('Basic Properties', () => {
     it('should have all required properties with correct types', () => {
       expect(resource).toBeInstanceOf(Resource);
-      expect(typeof resource.uuidResource).toBe('string');
+      expect(typeof resource.idResource).toBe('string');
       expect(typeof resource.title).toBe('string');
       expect(typeof resource.description).toBe('string');
       expect(typeof resource.content).toBe('string');
       expect(typeof resource.status).toBe('string');
-      expect(typeof resource.creatorUuid).toBe('string');
+      expect(typeof resource.idCreator).toBe('string');
       expect(resource.createdAt).toBeInstanceOf(Date);
       expect(resource.updatedAt).toBeInstanceOf(Date);
     });
@@ -43,17 +43,17 @@ describe('Resource Entity', () => {
   describe('Relationships', () => {
     it('should have a creator relationship with Member', () => {
       const member = new Member();
-      member.uuidMember = resource.creatorUuid;
+      member.idMember = resource.idCreator;
       resource.creator = member;
 
       expect(resource.creator).toBeDefined();
       expect(resource.creator).toBeInstanceOf(Member);
-      expect(resource.creator.uuidMember).toBe(resource.creatorUuid);
+      expect(resource.creator.idMember).toBe(resource.idCreator);
     });
 
     it('should have a reports relationship', () => {
       const report = new Report();
-      report.uuidReport = '123e4567-e89b-12d3-a456-426614174002';
+      report.idReport = '123e4567-e89b-12d3-a456-426614174002';
       resource.reports = [report];
 
       expect(resource.reports).toBeDefined();
@@ -63,7 +63,7 @@ describe('Resource Entity', () => {
 
     it('should have a comments relationship', () => {
       const comment = new Comment();
-      comment.uuidComment = '123e4567-e89b-12d3-a456-426614174003';
+      comment.idComment = '123e4567-e89b-12d3-a456-426614174003';
       resource.comments = [comment];
 
       expect(resource.comments).toBeDefined();
@@ -73,7 +73,7 @@ describe('Resource Entity', () => {
 
     it('should have a votes relationship', () => {
       const vote = new Vote();
-      vote.uuidVote = '123e4567-e89b-12d3-a456-426614174004';
+      vote.idVote = '123e4567-e89b-12d3-a456-426614174004';
       resource.votes = [vote];
 
       expect(resource.votes).toBeDefined();
@@ -85,16 +85,16 @@ describe('Resource Entity', () => {
   describe('Data Transformation', () => {
     it('should transform plain object to Resource instance', () => {
       const plainObject = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174000',
+        idResource: '123e4567-e89b-12d3-a456-426614174000',
         title: 'Test Resource',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
-        creatorUuid: '123e4567-e89b-12d3-a456-426614174001',
+        idCreator: '123e4567-e89b-12d3-a456-426614174001',
         createdAt: '2024-02-25T12:00:00Z',
         updatedAt: '2024-02-25T12:00:00Z',
         creator: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174001',
+          idMember: '123e4567-e89b-12d3-a456-426614174001',
         },
         reports: [],
         comments: [],
@@ -104,12 +104,12 @@ describe('Resource Entity', () => {
       const transformed = plainToInstance(Resource, plainObject, { enableImplicitConversion: true });
 
       expect(transformed).toBeInstanceOf(Resource);
-      expect(transformed.uuidResource).toBe(plainObject.uuidResource);
+      expect(transformed.idResource).toBe(plainObject.idResource);
       expect(transformed.title).toBe(plainObject.title);
       expect(transformed.description).toBe(plainObject.description);
       expect(transformed.content).toBe(plainObject.content);
       expect(transformed.status).toBe(plainObject.status);
-      expect(transformed.creatorUuid).toBe(plainObject.creatorUuid);
+      expect(transformed.idCreator).toBe(plainObject.idCreator);
       expect(transformed.createdAt).toBeInstanceOf(Date);
       expect(transformed.updatedAt).toBeInstanceOf(Date);
     });

--- a/src/resources/entities/resource.entity.ts
+++ b/src/resources/entities/resource.entity.ts
@@ -8,11 +8,11 @@ import { Vote } from '../../votes/entities/vote.entity';
 @Entity('resources')
 export class Resource {
   @ApiProperty({
-    description: 'UUID unique de la ressource',
+    description: 'id unique de la ressource',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_resource' })
-  uuidResource: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_resource' })
+  idResource: string;
 
   @ApiProperty({
     description: 'Le titre de la ressource',
@@ -45,18 +45,18 @@ export class Resource {
   status: string;
 
   @ApiProperty({
-    description: 'UUID du membre créateur',
+    description: 'id du membre créateur',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @Column({ type: 'uuid', name: 'creator_uuid' })
-  creatorUuid: string;
+  @Column({ type: 'uuid', name: 'id_creator' })
+  idCreator: string;
 
   @ApiProperty({
     description: 'Le membre qui a créé cette ressource',
     type: () => Member
   })
   @ManyToOne(() => Member, member => member.resources)
-  @JoinColumn({ name: 'creator_uuid' })
+  @JoinColumn({ name: 'id_creator' })
   creator: Member;
 
   @ApiProperty({

--- a/src/resources/resources.controller.spec.ts
+++ b/src/resources/resources.controller.spec.ts
@@ -45,14 +45,14 @@ describe('ResourcesController', () => {
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
       };
 
       const expectedResult = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         ...createResourceDto,
         creator: {
-          uuidMember: createResourceDto.uuidMember,
+          idMember: createResourceDto.idMember,
           username: 'testuser',
         },
         createdAt: new Date(),
@@ -75,26 +75,26 @@ describe('ResourcesController', () => {
       // Arrange
       const expectedResult = [
         {
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
           title: 'First Resource',
           description: 'First Description',
           content: 'First Content',
           status: 'active',
           creator: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+            idMember: '123e4567-e89b-12d3-a456-426614174000',
             username: 'testuser',
           },
           createdAt: new Date(),
           updatedAt: new Date(),
         },
         {
-          uuidResource: '123e4567-e89b-12d3-a456-426614174002',
+          idResource: '123e4567-e89b-12d3-a456-426614174002',
           title: 'Second Resource',
           description: 'Second Description',
           content: 'Second Content',
           status: 'active',
           creator: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+            idMember: '123e4567-e89b-12d3-a456-426614174000',
             username: 'testuser',
           },
           createdAt: new Date(),
@@ -116,15 +116,15 @@ describe('ResourcesController', () => {
   describe('findOne', () => {
     it('should return a single resource', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       const expectedResult = {
-        uuidResource: uuid,
+        idResource: idResource,
         title: 'Test Resource',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
         creator: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           username: 'testuser',
         },
         createdAt: new Date(),
@@ -134,42 +134,42 @@ describe('ResourcesController', () => {
       mockResourcesService.findOne.mockResolvedValue(expectedResult);
 
       // Act
-      const result = await controller.findOne(uuid);
+      const result = await controller.findOne(idResource);
 
       // Assert
-      expect(service.findOne).toHaveBeenCalledWith(uuid);
+      expect(service.findOne).toHaveBeenCalledWith(idResource);
       expect(result).toBe(expectedResult);
     });
 
     it('should throw NotFoundException when resource does not exist', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       mockResourcesService.findOne.mockRejectedValue(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with id ${idResource} not found`)
       );
 
       // Act & Assert
-      await expect(controller.findOne(uuid)).rejects.toThrow(NotFoundException);
-      expect(service.findOne).toHaveBeenCalledWith(uuid);
+      await expect(controller.findOne(idResource)).rejects.toThrow(NotFoundException);
+      expect(service.findOne).toHaveBeenCalledWith(idResource);
     });
   });
 
   describe('update', () => {
     it('should update a resource', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       const updateResourceDto: UpdateResourceDto = {
         title: 'Updated Resource',
         description: 'Updated Description',
       };
 
       const expectedResult = {
-        uuidResource: uuid,
+        idResource: idResource,
         ...updateResourceDto,
         content: 'Original Content',
         status: 'active',
         creator: {
-          uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+          idMember: '123e4567-e89b-12d3-a456-426614174000',
           username: 'testuser',
         },
         createdAt: new Date(),
@@ -179,78 +179,75 @@ describe('ResourcesController', () => {
       mockResourcesService.update.mockResolvedValue(expectedResult);
 
       // Act
-      const result = await controller.update(uuid, updateResourceDto);
-
-      // Assert
-      expect(service.update).toHaveBeenCalledWith(uuid, updateResourceDto);
+      const result = await controller.update(idResource, updateResourceDto);
       expect(result).toBe(expectedResult);
     });
 
     it('should throw NotFoundException when updating non-existent resource', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       const updateResourceDto: UpdateResourceDto = {
         title: 'Updated Resource',
       };
 
       mockResourcesService.update.mockRejectedValue(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with id ${idResource} not found`)
       );
 
       // Act & Assert
-      await expect(controller.update(uuid, updateResourceDto)).rejects.toThrow(
+      await expect(controller.update(idResource, updateResourceDto)).rejects.toThrow(
         NotFoundException
       );
-      expect(service.update).toHaveBeenCalledWith(uuid, updateResourceDto);
+      expect(service.update).toHaveBeenCalledWith(idResource, updateResourceDto);
     });
   });
 
   describe('remove', () => {
     it('should remove a resource', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       mockResourcesService.remove.mockResolvedValue(undefined);
 
       // Act
-      await controller.remove(uuid);
+      await controller.remove(idResource);
 
       // Assert
-      expect(service.remove).toHaveBeenCalledWith(uuid);
+      expect(service.remove).toHaveBeenCalledWith(idResource);
     });
 
     it('should throw NotFoundException when removing non-existent resource', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       mockResourcesService.remove.mockRejectedValue(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with id ${idResource} not found`)
       );
 
       // Act & Assert
-      await expect(controller.remove(uuid)).rejects.toThrow(NotFoundException);
-      expect(service.remove).toHaveBeenCalledWith(uuid);
+      await expect(controller.remove(idResource)).rejects.toThrow(NotFoundException);
+      expect(service.remove).toHaveBeenCalledWith(idResource);
     });
   });
 
   describe('findComments', () => {
     it('should return comments for a resource', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       const expectedResult = [
         {
-          uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+          idComment: '123e4567-e89b-12d3-a456-426614174002',
           content: 'First Comment',
           member: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+            idMember: '123e4567-e89b-12d3-a456-426614174000',
             username: 'testuser',
           },
           createdAt: new Date(),
           updatedAt: new Date(),
         },
         {
-          uuidComment: '123e4567-e89b-12d3-a456-426614174003',
+          idComment: '123e4567-e89b-12d3-a456-426614174003',
           content: 'Second Comment',
           member: {
-            uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+            idMember: '123e4567-e89b-12d3-a456-426614174000',
             username: 'testuser',
           },
           createdAt: new Date(),
@@ -261,35 +258,35 @@ describe('ResourcesController', () => {
       mockResourcesService.findComments.mockResolvedValue(expectedResult);
 
       // Act
-      const result = await controller.findComments(uuid);
+      const result = await controller.findComments(idResource);
 
       // Assert
-      expect(service.findComments).toHaveBeenCalledWith(uuid);
+      expect(service.findComments).toHaveBeenCalledWith(idResource);
       expect(result).toBe(expectedResult);
     });
 
     it('should throw NotFoundException when resource does not exist', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       mockResourcesService.findComments.mockRejectedValue(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with id ${idResource} not found`)
       );
 
       // Act & Assert
-      await expect(controller.findComments(uuid)).rejects.toThrow(NotFoundException);
-      expect(service.findComments).toHaveBeenCalledWith(uuid);
+      await expect(controller.findComments(idResource)).rejects.toThrow(NotFoundException);
+      expect(service.findComments).toHaveBeenCalledWith(idResource);
     });
 
     it('should return empty array when resource has no comments', async () => {
       // Arrange
-      const uuid = '123e4567-e89b-12d3-a456-426614174001';
+      const idResource = '123e4567-e89b-12d3-a456-426614174001';
       mockResourcesService.findComments.mockResolvedValue([]);
 
       // Act
-      const result = await controller.findComments(uuid);
+      const result = await controller.findComments(idResource);
 
       // Assert
-      expect(service.findComments).toHaveBeenCalledWith(uuid);
+      expect(service.findComments).toHaveBeenCalledWith(idResource);
       expect(result).toEqual([]);
       expect(Array.isArray(result)).toBe(true);
     });

--- a/src/resources/resources.controller.ts
+++ b/src/resources/resources.controller.ts
@@ -40,16 +40,16 @@ export class ResourcesController {
   })
   findAll(): Promise<ResourceResponseDto[]> {
     return this.resourcesService.findAll();
-  }
+  } 
 
-  @Get(':uuid')
+  @Get(':id')
   @ApiOperation({ 
-    summary: 'Récupérer une ressource par son UUID',
+    summary: 'Récupérer une ressource par son id',
     description: 'Retourne les détails d\'une ressource spécifique avec toutes ses relations.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID de la ressource à récupérer',
+    name: 'id',
+    description: 'id de la ressource à récupérer',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -58,18 +58,18 @@ export class ResourcesController {
     type: ResourceResponseDto 
   })
   @ApiResponse({ status: 404, description: 'Ressource non trouvée' })
-  findOne(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<ResourceResponseDto> {
-    return this.resourcesService.findOne(uuid);
+  findOne(@Param('id', ParseUUIDPipe) idResource: string): Promise<ResourceResponseDto> {
+    return this.resourcesService.findOne(idResource);
   }
 
-  @Get(':uuid/comments')
+  @Get(':id/comments')
   @ApiOperation({ 
     summary: 'Récupérer tous les commentaires d\'une ressource',
     description: 'Retourne la liste de tous les commentaires associés à une ressource spécifique.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID de la ressource',
+    name: 'id',
+    description: 'id de la ressource',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -78,18 +78,18 @@ export class ResourcesController {
     type: [Comment] 
   })
   @ApiResponse({ status: 404, description: 'Ressource non trouvée' })
-  findComments(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<Comment[]> {
-    return this.resourcesService.findComments(uuid);
+  findComments(@Param('id', ParseUUIDPipe) idResource: string): Promise<Comment[]> {
+    return this.resourcesService.findComments(idResource);
   }
 
-  @Put(':uuid')
+  @Put(':id')
   @ApiOperation({ 
     summary: 'Mettre à jour une ressource',
     description: 'Met à jour les informations d\'une ressource existante.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID de la ressource à mettre à jour',
+    name: 'id',
+    description: 'id de la ressource à mettre à jour',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -100,20 +100,20 @@ export class ResourcesController {
   @ApiResponse({ status: 400, description: 'Données invalides' })
   @ApiResponse({ status: 404, description: 'Ressource non trouvée' })
   update(
-    @Param('uuid', ParseUUIDPipe) uuid: string,
+    @Param('id', ParseUUIDPipe) idResource: string,
     @Body() updateResourceDto: UpdateResourceDto,
   ): Promise<ResourceResponseDto> {
-    return this.resourcesService.update(uuid, updateResourceDto);
+    return this.resourcesService.update(idResource, updateResourceDto);
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ 
     summary: 'Supprimer une ressource',
     description: 'Supprime une ressource existante de la base de données.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID de la ressource à supprimer',
+    name: 'id',
+    description: 'id de la ressource à supprimer',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -121,7 +121,7 @@ export class ResourcesController {
     description: 'La ressource a été supprimée avec succès.' 
   })
   @ApiResponse({ status: 404, description: 'Ressource non trouvée' })
-  remove(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<void> {
-    return this.resourcesService.remove(uuid);
+  remove(@Param('id', ParseUUIDPipe) idResource: string): Promise<void> {
+    return this.resourcesService.remove(idResource);
   }
 } 

--- a/src/resources/resources.service.spec.ts
+++ b/src/resources/resources.service.spec.ts
@@ -64,7 +64,7 @@ describe('ResourcesService', () => {
     it('should successfully create a resource', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
@@ -74,11 +74,11 @@ describe('ResourcesService', () => {
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
-        uuidMember: mockMember.uuidMember,
+        idMember: mockMember.idMember,
       };
 
       const mockCreatedResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         ...createResourceDto,
         creator: mockMember,
         createdAt: new Date(),
@@ -100,7 +100,7 @@ describe('ResourcesService', () => {
 
       // Assert
       expect(mockMemberRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidMember: createResourceDto.uuidMember },
+        where: { idMember: createResourceDto.idMember },
       });
       expect(mockResourceRepository.create).toHaveBeenCalledWith({
         title: createResourceDto.title,
@@ -108,7 +108,7 @@ describe('ResourcesService', () => {
         content: createResourceDto.content,
         status: createResourceDto.status,
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
       });
       expect(mockResourceRepository.save).toHaveBeenCalledWith(mockCreatedResource);
       expect(result).toBeDefined();
@@ -122,17 +122,17 @@ describe('ResourcesService', () => {
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
       };
 
       mockMemberRepository.findOne.mockResolvedValue(null);
 
       // Act & Assert
       await expect(service.create(createResourceDto)).rejects.toThrow(
-        `Member with UUID ${createResourceDto.uuidMember} not found`
+        `Member with UUID ${createResourceDto.idMember} not found`
       );
       expect(mockMemberRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidMember: createResourceDto.uuidMember },
+        where: { idMember: createResourceDto.idMember },
       });
       expect(mockResourceRepository.create).not.toHaveBeenCalled();
       expect(mockResourceRepository.save).not.toHaveBeenCalled();
@@ -143,36 +143,36 @@ describe('ResourcesService', () => {
     it('should return a resource with all its relations when it exists', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Test Resource',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
         comments: [
           {
-            uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+            idComment: '123e4567-e89b-12d3-a456-426614174002',
             content: 'Test Comment',
             member: mockMember,
           },
         ],
         votes: [
           {
-            uuidVote: '123e4567-e89b-12d3-a456-426614174003',
+            idVote: '123e4567-e89b-12d3-a456-426614174003',
             voteType: 'upvote',
             member: mockMember,
           },
         ],
         reports: [
           {
-            uuidReport: '123e4567-e89b-12d3-a456-426614174004',
+            idReport: '123e4567-e89b-12d3-a456-426614174004',
             type: 'resource',
             reason: 'Test Report',
             reporter: mockMember,
@@ -185,11 +185,11 @@ describe('ResourcesService', () => {
       mockResourceRepository.findOne.mockResolvedValue(mockResource);
 
       // Act
-      const result = await service.findOne(mockResource.uuidResource);
+      const result = await service.findOne(mockResource.idResource);
 
       // Assert
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: mockResource.uuidResource },
+        where: { idResource: mockResource.idResource },
         relations: [
           'creator',
           'reports',
@@ -203,7 +203,7 @@ describe('ResourcesService', () => {
         ],
       });
       expect(result).toBeDefined();
-      expect(result.uuidResource).toBe(mockResource.uuidResource);
+      expect(result.idResource).toBe(mockResource.idResource);
       expect(result.title).toBe(mockResource.title);
       expect(result.creator).toBeDefined();
       expect(result.comments).toHaveLength(1);
@@ -218,10 +218,10 @@ describe('ResourcesService', () => {
 
       // Act & Assert
       await expect(service.findOne(uuid)).rejects.toThrow(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with UUID ${id} not found`)
       );
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: uuid },
+        where: { idResource: id },
         relations: [
           'creator',
           'reports',
@@ -241,30 +241,30 @@ describe('ResourcesService', () => {
     it('should return all resources with their relations sorted by creation date', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const mockResources = [
         {
-          uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+          idResource: '123e4567-e89b-12d3-a456-426614174001',
           title: 'First Resource',
           description: 'First Description',
           content: 'First Content',
           status: 'active',
           creator: mockMember,
-          creatorUuid: mockMember.uuidMember,
+          idCreator: mockMember.idMember,
           comments: [
             {
-              uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+              idComment: '123e4567-e89b-12d3-a456-426614174002',
               content: 'Test Comment',
               member: mockMember,
             },
           ],
           votes: [
             {
-              uuidVote: '123e4567-e89b-12d3-a456-426614174003',
+              idVote: '123e4567-e89b-12d3-a456-426614174003',
               voteType: 'upvote',
               member: mockMember,
             },
@@ -274,13 +274,13 @@ describe('ResourcesService', () => {
           updatedAt: new Date('2024-03-15'),
         },
         {
-          uuidResource: '123e4567-e89b-12d3-a456-426614174004',
+          idResource: '123e4567-e89b-12d3-a456-426614174004',
           title: 'Second Resource',
           description: 'Second Description',
           content: 'Second Content',
           status: 'active',
           creator: mockMember,
-          creatorUuid: mockMember.uuidMember,
+          idCreator: mockMember.idMember,
           comments: [],
           votes: [],
           reports: [],
@@ -354,22 +354,22 @@ describe('ResourcesService', () => {
     it('should update a resource and maintain its relations', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const existingResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Original Title',
         description: 'Original Description',
         content: 'Original Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
         comments: [
           {
-            uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+            idComment: '123e4567-e89b-12d3-a456-426614174002',
             content: 'Test Comment',
             member: mockMember,
           },
@@ -399,11 +399,11 @@ describe('ResourcesService', () => {
       mockResourceRepository.save.mockResolvedValue(updatedResource);
 
       // Act
-      const result = await service.update(existingResource.uuidResource, updateResourceDto);
+      const result = await service.update(existingResource.idResource, updateResourceDto);
 
       // Assert
       expect(mockResourceRepository.findOne).toHaveBeenNthCalledWith(1, {
-        where: { uuidResource: existingResource.uuidResource }
+        where: { idResource: existingResource.idResource }
       });
 
       expect(mockResourceRepository.save).toHaveBeenCalledWith({
@@ -412,7 +412,7 @@ describe('ResourcesService', () => {
       });
 
       expect(mockResourceRepository.findOne).toHaveBeenNthCalledWith(2, {
-        where: { uuidResource: existingResource.uuidResource },
+        where: { idResource: existingResource.idResource },
         relations: [
           'creator',
           'reports',
@@ -445,11 +445,11 @@ describe('ResourcesService', () => {
 
       // Act & Assert
       await expect(service.update(uuid, updateResourceDto)).rejects.toThrow(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with UUID ${id} not found`)
       );
 
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: uuid }
+        where: { idResource: id }
       });
       expect(mockResourceRepository.save).not.toHaveBeenCalled();
     });
@@ -457,19 +457,19 @@ describe('ResourcesService', () => {
     it('should only update provided fields', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const existingResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Original Title',
         description: 'Original Description',
         content: 'Original Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
         comments: [],
         votes: [],
         reports: [],
@@ -495,7 +495,7 @@ describe('ResourcesService', () => {
       mockResourceRepository.save.mockResolvedValue(updatedResource);
 
       // Act
-      const result = await service.update(existingResource.uuidResource, updateResourceDto);
+      const result = await service.update(existingResource.idResource, updateResourceDto);
 
       // Assert
       expect(mockResourceRepository.save).toHaveBeenCalledWith({
@@ -513,22 +513,22 @@ describe('ResourcesService', () => {
     it('should remove an existing resource', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const existingResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Resource to Delete',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
         comments: [
           {
-            uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+            idComment: '123e4567-e89b-12d3-a456-426614174002',
             content: 'Test Comment',
             member: mockMember,
           },
@@ -543,11 +543,11 @@ describe('ResourcesService', () => {
       mockResourceRepository.remove.mockResolvedValue(existingResource);
 
       // Act
-      await service.remove(existingResource.uuidResource);
+      await service.remove(existingResource.idResource);
 
       // Assert
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: existingResource.uuidResource }
+        where: { idResource: existingResource.idResource }
       });
       expect(mockResourceRepository.remove).toHaveBeenCalledWith(existingResource);
     });
@@ -559,10 +559,10 @@ describe('ResourcesService', () => {
 
       // Act & Assert
       await expect(service.remove(uuid)).rejects.toThrow(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with UUID ${id} not found`)
       );
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: uuid }
+        where: { idResource: id }
       });
       expect(mockResourceRepository.remove).not.toHaveBeenCalled();
     });
@@ -570,36 +570,36 @@ describe('ResourcesService', () => {
     it('should cascade delete related entities', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const existingResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Resource to Delete',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
         comments: [
           {
-            uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+            idComment: '123e4567-e89b-12d3-a456-426614174002',
             content: 'Test Comment',
             member: mockMember,
           },
         ],
         votes: [
           {
-            uuidVote: '123e4567-e89b-12d3-a456-426614174003',
+            idVote: '123e4567-e89b-12d3-a456-426614174003',
             voteType: 'upvote',
             member: mockMember,
           },
         ],
         reports: [
           {
-            uuidReport: '123e4567-e89b-12d3-a456-426614174004',
+            idReport: '123e4567-e89b-12d3-a456-426614174004',
             type: 'resource',
             reason: 'Test Report',
             reporter: mockMember,
@@ -613,11 +613,11 @@ describe('ResourcesService', () => {
       mockResourceRepository.remove.mockResolvedValue(existingResource);
 
       // Act
-      await service.remove(existingResource.uuidResource);
+      await service.remove(existingResource.idResource);
 
       // Assert
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: existingResource.uuidResource }
+        where: { idResource: existingResource.idResource }
       });
       expect(mockResourceRepository.remove).toHaveBeenCalledWith(existingResource);
       // La suppression en cascade est gérée par TypeORM via les décorateurs @OneToMany
@@ -628,30 +628,30 @@ describe('ResourcesService', () => {
     it('should return all comments for a resource with their relations', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Test Resource',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
       };
 
       const mockComments = [
         {
-          uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+          idComment: '123e4567-e89b-12d3-a456-426614174002',
           content: 'First Comment',
           member: mockMember,
           resource: mockResource,
           votes: [
             {
-              uuidVote: '123e4567-e89b-12d3-a456-426614174003',
+              idVote: '123e4567-e89b-12d3-a456-426614174003',
               voteType: 'upvote',
               member: mockMember,
             },
@@ -660,7 +660,7 @@ describe('ResourcesService', () => {
           updatedAt: new Date('2024-03-15'),
         },
         {
-          uuidComment: '123e4567-e89b-12d3-a456-426614174004',
+          idComment: '123e4567-e89b-12d3-a456-426614174004',
           content: 'Second Comment',
           member: mockMember,
           resource: mockResource,
@@ -674,14 +674,14 @@ describe('ResourcesService', () => {
       mockCommentRepository.find.mockResolvedValue(mockComments);
 
       // Act
-      const result = await service.findComments(mockResource.uuidResource);
+      const result = await service.findComments(mockResource.idResource);
 
       // Assert
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: mockResource.uuidResource }
+        where: { idResource: mockResource.idResource }
       });
       expect(mockCommentRepository.find).toHaveBeenCalledWith({
-        where: { uuidResource: mockResource.uuidResource },
+        where: { idResource: mockResource.idResource },
         relations: ['member', 'resource', 'votes', 'votes.member'],
         order: { createdAt: 'DESC' }
       });
@@ -700,10 +700,10 @@ describe('ResourcesService', () => {
 
       // Act & Assert
       await expect(service.findComments(uuid)).rejects.toThrow(
-        new NotFoundException(`Resource with UUID ${uuid} not found`)
+        new NotFoundException(`Resource with UUID ${id} not found`)
       );
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: uuid }
+        where: { idResource: id }
       });
       expect(mockCommentRepository.find).not.toHaveBeenCalled();
     });
@@ -711,33 +711,33 @@ describe('ResourcesService', () => {
     it('should return empty array when resource has no comments', async () => {
       // Arrange
       const mockMember = {
-        uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+        idMember: '123e4567-e89b-12d3-a456-426614174000',
         username: 'testuser',
         status: 'active',
       };
 
       const mockResource = {
-        uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+        idResource: '123e4567-e89b-12d3-a456-426614174001',
         title: 'Test Resource',
         description: 'Test Description',
         content: 'Test Content',
         status: 'active',
         creator: mockMember,
-        creatorUuid: mockMember.uuidMember,
+        idCreator: mockMember.idMember,
       };
 
       mockResourceRepository.findOne.mockResolvedValue(mockResource);
       mockCommentRepository.find.mockResolvedValue([]);
 
       // Act
-      const result = await service.findComments(mockResource.uuidResource);
+      const result = await service.findComments(mockResource.idResource);
 
       // Assert
       expect(mockResourceRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidResource: mockResource.uuidResource }
+        where: { idResource: mockResource.idResource }
       });
       expect(mockCommentRepository.find).toHaveBeenCalledWith({
-        where: { uuidResource: mockResource.uuidResource },
+        where: { idResource: mockResource.idResource },
         relations: ['member', 'resource', 'votes', 'votes.member'],
         order: { createdAt: 'DESC' }
       });

--- a/src/resources/resources.service.ts
+++ b/src/resources/resources.service.ts
@@ -21,26 +21,26 @@ export class ResourcesService {
   ) {}
 
   async create(createResourceDto: CreateResourceDto): Promise<ResourceResponseDto> {
-    const { uuidMember, ...resourceData } = createResourceDto;
+    const { idMember, ...resourceData } = createResourceDto;
     
     // On cherche le membre
     const member = await this.membersRepository.findOne({
-      where: { uuidMember }
+      where: { idMember }
     });
     if (!member) {
-      throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+      throw new NotFoundException(`Member with id ${idMember} not found`);
     }
 
-    // On crée la ressource avec le membre et son UUID
+    // On crée la ressource avec le membre et son id
     const resource = this.resourcesRepository.create({
       ...resourceData,
       creator: member,
-      creatorUuid: member.uuidMember
+      idCreator: member.idMember
     });
     
     const savedResource = await this.resourcesRepository.save(resource);
     const resourceWithRelations = await this.resourcesRepository.findOne({
-      where: { uuidResource: savedResource.uuidResource },
+      where: { idResource: savedResource.idResource },
       relations: [
         'creator',
         'reports',
@@ -78,9 +78,9 @@ export class ResourcesService {
     );
   }
 
-  async findOne(uuid: string): Promise<ResourceResponseDto> {
+  async findOne(idResource: string): Promise<ResourceResponseDto> {
     const resource = await this.resourcesRepository.findOne({
-      where: { uuidResource: uuid },
+      where: { idResource: idResource },
       relations: [
         'creator',
         'reports',
@@ -95,25 +95,25 @@ export class ResourcesService {
     });
 
     if (!resource) {
-      throw new NotFoundException(`Resource with UUID ${uuid} not found`);
+      throw new NotFoundException(`Resource with id ${idResource} not found`);
     }
 
     return plainToInstance(ResourceResponseDto, resource, { excludeExtraneousValues: true });
   }
 
-  async findComments(uuid: string): Promise<Comment[]> {
+  async findComments(idResource: string): Promise<Comment[]> {
     // Vérifie d'abord si la ressource existe
     const resource = await this.resourcesRepository.findOne({
-      where: { uuidResource: uuid }
+      where: { idResource: idResource }
     });
 
     if (!resource) {
-      throw new NotFoundException(`Resource with UUID ${uuid} not found`);
+      throw new NotFoundException(`Resource with id ${idResource} not found`);
     }
 
     // Récupère les commentaires de la ressource
     const comments = await this.commentsRepository.find({
-      where: { uuidResource: uuid },
+      where: { idResource: idResource },
       relations: ['member', 'resource', 'votes', 'votes.member'],
       order: {
         createdAt: 'DESC'
@@ -123,13 +123,13 @@ export class ResourcesService {
     return comments;
   }
 
-  async update(uuid: string, updateResourceDto: UpdateResourceDto): Promise<ResourceResponseDto> {
+  async update(idResource: string, updateResourceDto: UpdateResourceDto): Promise<ResourceResponseDto> {
     const existingResource = await this.resourcesRepository.findOne({
-      where: { uuidResource: uuid }
+      where: { idResource: idResource }
     });
     
     if (!existingResource) {
-      throw new NotFoundException(`Resource with UUID ${uuid} not found`);
+      throw new NotFoundException(`Resource with id ${idResource} not found`);
     }
 
     const updatedResource = await this.resourcesRepository.save({
@@ -138,7 +138,7 @@ export class ResourcesService {
     });
 
     const resourceWithRelations = await this.resourcesRepository.findOne({
-      where: { uuidResource: updatedResource.uuidResource },
+      where: { idResource: updatedResource.idResource },
       relations: [
         'creator',
         'reports',
@@ -155,13 +155,13 @@ export class ResourcesService {
     return plainToInstance(ResourceResponseDto, resourceWithRelations, { excludeExtraneousValues: true });
   }
 
-  async remove(uuid: string): Promise<void> {
+  async remove(idResource: string): Promise<void> {
     const resource = await this.resourcesRepository.findOne({
-      where: { uuidResource: uuid }
+      where: { idResource: idResource }
     });
     
     if (!resource) {
-      throw new NotFoundException(`Resource with UUID ${uuid} not found`);
+      throw new NotFoundException(`Resource with id ${idResource} not found`);
     }
 
     await this.resourcesRepository.remove(resource);

--- a/src/roles/dto/assign-role-to-member.dto.ts
+++ b/src/roles/dto/assign-role-to-member.dto.ts
@@ -1,20 +1,20 @@
 import { PickType, ApiProperty } from "@nestjs/swagger";
 
-import { PickableInternUUIDFields } from "src/utils/pickable-intern-uuid-fields";
+import { PickableInternIdFields } from "src/utils/pickable-intern-id-fields";
 
 import { ArrayNotEmpty, ArrayUnique, IsString, Matches } from "class-validator";
 
-export class AssignRoleToMemberDto extends PickType(PickableInternUUIDFields, [
-    'uuidMember',
+export class AssignRoleToMemberDto extends PickType(PickableInternIdFields, [
+    'idMember',
 ]) {
 
     @ApiProperty({
-        description: "Liste des UUID des rôles à attribuer au membre",
+        description: "Liste des id des rôles à attribuer au membre",
         example: ["12345678901234567", "123456789012345678", "1234567890123456789"]
     })
     @ArrayNotEmpty()
     @ArrayUnique()
     @IsString({ each: true }) // Assure que chaque élément est une chaîne
-    @Matches(/^\d{17,19}$/, { each: true, message: "Chaque uuidRole doit être un Snowflake Discord valide (17 à 19 chiffres uniquement)" })
-    uuidRoles: string[];
+    @Matches(/^\d{17,19}$/, { each: true, message: "Chaque idRole doit être un Snowflake Discord valide (17 à 19 chiffres uniquement)" })
+    idRoles: string[];
 }

--- a/src/roles/dto/create-role.dto.ts
+++ b/src/roles/dto/create-role.dto.ts
@@ -1,10 +1,10 @@
 import { IsString, IsUUID, MaxLength, IsBoolean, Matches } from 'class-validator';
 import { ApiProperty, IntersectionType, PickType } from '@nestjs/swagger';
 import { PickableDtoFields } from 'src/utils/pickable-dto-fields';
-import { PickableDiscordUUIDFields } from 'src/utils/pickable-discord-uuid-fields';
+import { PickableDiscordIdFields} from 'src/utils/pickable-discord-id-fields';
 
-export class CreateRoleDto extends PickType(IntersectionType(PickableDtoFields, PickableDiscordUUIDFields), [
-    'uuidRole', 'name', 'uuidGuild'
+export class CreateRoleDto extends PickType(IntersectionType(PickableDtoFields, PickableDiscordIdFields), [
+    'idRole', 'name', 'idGuild'
 ]) {
     
     @ApiProperty({

--- a/src/roles/dto/update-member-roles.dto.ts
+++ b/src/roles/dto/update-member-roles.dto.ts
@@ -2,5 +2,5 @@ import { OmitType } from "@nestjs/swagger";
 import { AssignRoleToMemberDto } from "./assign-role-to-member.dto";
 
 export class UpdateMemberRolesDto extends OmitType(AssignRoleToMemberDto, [
-    'uuidMember'] as const) {}
+    'idMember'] as const) {}
 

--- a/src/roles/entities/role.entity.ts
+++ b/src/roles/entities/role.entity.ts
@@ -9,11 +9,11 @@ import { Promotion } from 'src/promotions/entities/promotion.entity';
 @Entity('roles')
 export class Role {
   @ApiProperty({
-    description: 'UUID unique du rôle',
+    description: 'SF unique du rôle',
     example: '172653890987364567'
   })
-  @PrimaryColumn('varchar', { name: 'uuid_role' })
-  uuidRole: string;
+  @PrimaryColumn({ type: 'varchar', length: 19,  name: 'id_role' })
+  idRole: string;
 
   @ApiProperty({
     description: 'Nom du rôle',
@@ -66,18 +66,18 @@ export class Role {
   updatedAt: Date;
 
   @ApiProperty({
-    description: 'UUID de la guilde à laquelle appartient le rôle',
+    description: 'id de la guilde à laquelle appartient le rôle',
     example: '123456789012345678'
   })
-  @Column('uuid', { name: 'uuid_guild', nullable: false })
-  uuidGuild: string;
+  @Column('uuid', { name: 'id_guild', nullable: false })
+  idGuild: string;
 
   @ApiProperty({
     description: 'Relation avec la guilde',
     type: () => Guild
   })
   @ManyToOne(() => Guild, guild => guild.roles, { onDelete: 'CASCADE' })
-  @JoinColumn({ name: 'uuid_guild' })
+  @JoinColumn({ name: 'id_guild' })
   guild: Guild;
 
   @ApiProperty({

--- a/src/roles/roles.controller.spec.ts
+++ b/src/roles/roles.controller.spec.ts
@@ -11,7 +11,7 @@ describe('RolesController', () => {
   let rolesService: RolesService;
 
   const mockGuild: Guild = {
-    uuid: '123e4567-e89b-12d3-a456-426614174001',
+    idGuild: '123e4567-e89b-12d3-a456-426614174001',
     name: 'Test Guild',
     memberCount: 10,
     configuration: {},
@@ -20,15 +20,15 @@ describe('RolesController', () => {
   };
 
   const mockRole: Role = {
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    idRole: '123e4567-e89b-12d3-a456-426614174000',
     name: 'Test Role',
-    member_count: '10',
+    memberCount: '10',
     role_position: '1',
     hoist: true,
     color: '#FF0000',
     createdAt: new Date(),
     updatedAt: new Date(),
-    uuidGuild: '123e4567-e89b-12d3-a456-426614174001',
+    idGuild: '123e4567-e89b-12d3-a456-426614174001',
     guild: mockGuild
   };
 
@@ -47,13 +47,13 @@ describe('RolesController', () => {
   describe('create', () => {
     it('devrait créer un nouveau rôle', async () => {
       const createRoleDto: CreateRoleDto = {
-        uuidRole: '123e4567-e89b-12d3-a456-426614174000',
+        idRole: '123e4567-e89b-12d3-a456-426614174000',
         name: 'Test Role',
-        member_count: '10',
-        role_position: '1',
+        memberCount: '10',
+        rolePosition: '1',
         hoist: true,
         color: '#FF0000',
-        uuidGuild: '123e4567-e89b-12d3-a456-426614174001'
+        idGuild: '123e4567-e89b-12d3-a456-426614174001'
       };
 
       vi.mocked(rolesService.create).mockResolvedValue(mockRole);
@@ -78,13 +78,13 @@ describe('RolesController', () => {
   });
 
   describe('findOne', () => {
-    it('devrait retourner un rôle par son uuid', async () => {
+    it('devrait retourner un rôle par son id', async () => {
       vi.mocked(rolesService.findOne).mockResolvedValue(mockRole);
 
-      const result = await controller.findOne(mockRole.uuid);
+      const result = await controller.findOne(mockRole.idRole);
 
       expect(result).toEqual(mockRole);
-      expect(rolesService.findOne).toHaveBeenCalledWith(mockRole.uuid);
+      expect(rolesService.findOne).toHaveBeenCalledWith(mockRole.idRole);
     });
   });
 
@@ -98,10 +98,10 @@ describe('RolesController', () => {
 
       vi.mocked(rolesService.update).mockResolvedValue(updatedRole);
 
-      const result = await controller.update(mockRole.uuid, updateRoleDto);
+      const result = await controller.update(mockRole.idRole, updateRoleDto);
 
       expect(result).toEqual(updatedRole);
-      expect(rolesService.update).toHaveBeenCalledWith(mockRole.uuid, updateRoleDto);
+      expect(rolesService.update).toHaveBeenCalledWith(mockRole.idRole, updateRoleDto);
     });
   });
 
@@ -109,10 +109,10 @@ describe('RolesController', () => {
     it('devrait supprimer un rôle', async () => {
       vi.mocked(rolesService.remove).mockResolvedValue(undefined);
 
-      const result = await controller.remove(mockRole.uuid);
+      const result = await controller.remove(mockRole.idRole);
 
       expect(result).toBeUndefined();
-      expect(rolesService.remove).toHaveBeenCalledWith(mockRole.uuid);
+      expect(rolesService.remove).toHaveBeenCalledWith(mockRole.idRole);
     });
   });
 });

--- a/src/roles/roles.controller.ts
+++ b/src/roles/roles.controller.ts
@@ -43,14 +43,14 @@ export class RolesController {
     return this.rolesService.findAll();
   }
 
-  @Get(':uuid')
+  @Get(':id')
   @ApiOperation({ 
-    summary: 'Récupérer un rôle par son UUID',
-    description: 'Recherche et retourne un rôle spécifique en utilisant son UUID.'
+    summary: 'Récupérer un rôle par son id',
+    description: 'Recherche et retourne un rôle spécifique en utilisant son id.'
   })
   @ApiParam({ 
-    name: 'uuid', 
-    description: 'UUID unique du rôle à rechercher',
+    name: 'id', 
+    description: 'id unique du rôle à rechercher',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -60,20 +60,20 @@ export class RolesController {
   })
   @ApiResponse({ 
     status: HttpStatus.NOT_FOUND, 
-    description: 'Aucun rôle trouvé avec l\'UUID fourni.' 
+    description: 'Aucun rôle trouvé avec l\'id fourni.' 
   })
-  findOne(@Param('uuid') uuid: string) {
-    return this.rolesService.findOne(uuid);
+  findOne(@Param('id') idRole: string) {
+    return this.rolesService.findOne(idRole);
   }
 
-  @Patch(':uuid')
+  @Patch(':id')
   @ApiOperation({ 
     summary: 'Mettre à jour un rôle',
-    description: 'Met à jour les informations d\'un rôle existant en utilisant son UUID.'
+    description: 'Met à jour les informations d\'un rôle existant en utilisant son id.'
   })
   @ApiParam({ 
-    name: 'uuid', 
-    description: 'UUID unique du rôle à mettre à jour',
+    name: 'id', 
+    description: 'id unique du rôle à mettre à jour',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiBody({ type: UpdateRoleDto })
@@ -88,20 +88,20 @@ export class RolesController {
   })
   @ApiResponse({ 
     status: HttpStatus.NOT_FOUND, 
-    description: 'Aucun rôle trouvé avec l\'UUID fourni.' 
+    description: 'Aucun rôle trouvé avec l\'id fourni.' 
   })
-  update(@Param('uuid') uuid: string, @Body() updateRoleDto: UpdateRoleDto) {
-    return this.rolesService.update(uuid, updateRoleDto);
+  update(@Param('id') idRole: string, @Body() updateRoleDto: UpdateRoleDto) {
+    return this.rolesService.update(idRole, updateRoleDto);
   }
 
-  @Delete(':uuid')
+  @Delete(':id')
   @ApiOperation({ 
     summary: 'Supprimer un rôle',
-    description: 'Supprime un rôle existant de la base de données en utilisant son UUID.'
+    description: 'Supprime un rôle existant de la base de données en utilisant son id.'
   })
   @ApiParam({ 
-    name: 'uuid', 
-    description: 'UUID unique du rôle à supprimer',
+    name: 'id', 
+    description: 'id unique du rôle à supprimer',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -110,9 +110,9 @@ export class RolesController {
   })
   @ApiResponse({ 
     status: HttpStatus.NOT_FOUND, 
-    description: 'Aucun rôle trouvé avec l\'UUID fourni.' 
+    description: 'Aucun rôle trouvé avec l\'id fourni.' 
   })
-  remove(@Param('uuid') uuid: string) {
-    return this.rolesService.remove(uuid);
+  remove(@Param('id') idRole: string) {
+    return this.rolesService.remove(idRole);
   }
 }

--- a/src/roles/roles.service.spec.ts
+++ b/src/roles/roles.service.spec.ts
@@ -11,7 +11,7 @@ describe('RolesService', () => {
   let repository: Repository<Role>;
 
   const mockRole: Role = {
-    uuidRole: '123e4567-e89b-12d3-a456-426614174000',
+    idRole: '123e4567-e89b-12d3-a456-426614174000',
     name: 'Test Role',
     memberCount: 10,
     rolePosition: 1,
@@ -19,7 +19,7 @@ describe('RolesService', () => {
     color: '#FF0000',
     createdAt: new Date(),
     updatedAt: new Date(),
-    uuidGuild: '123e4567-e89b-12d3-a456-426614174001',
+    idGuild: '123e4567-e89b-12d3-a456-426614174001',
     guild: null
   };
 
@@ -54,7 +54,7 @@ describe('RolesService', () => {
         rolePosition: '1',
         hoist: true,
         color: '#FF0000',
-        uuidGuild: '123e4567-e89b-12d3-a456-426614174001'
+        idGuild: '123e4567-e89b-12d3-a456-426614174001'
       };
 
       const roleDataWithParsedNumbers = {
@@ -87,13 +87,13 @@ describe('RolesService', () => {
   });
 
   describe('findOne', () => {
-    it('devrait retourner un rôle par son uuid', async () => {
+    it('devrait retourner un rôle par son id', async () => {
       mockRepository.findOneBy.mockResolvedValue(mockRole);
 
-      const result = await service.findOne(mockRole.uuidRole);
+      const result = await service.findOne(mockRole.idRole);
 
       expect(result).toEqual(mockRole);
-      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ uuidRole: mockRole.uuidRole });
+      expect(mockRepository.findOneBy).toHaveBeenCalledWith({ idRole: mockRole.idRole });
     });
 
     it('devrait lancer une erreur si le rôle n\'est pas trouvé', async () => {
@@ -116,7 +116,7 @@ describe('RolesService', () => {
       mockRepository.findOneBy.mockResolvedValue(mockRole);
       mockRepository.save.mockResolvedValue(updatedRole);
 
-      const result = await service.update(mockRole.uuidRole, updateRoleDto);
+      const result = await service.update(mockRole.idRole, updateRoleDto);
 
       expect(result).toEqual(updatedRole);
       expect(mockRepository.save).toHaveBeenCalled();
@@ -135,9 +135,9 @@ describe('RolesService', () => {
     it('devrait supprimer un rôle', async () => {
       mockRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.remove(mockRole.uuidRole);
+      await service.remove(mockRole.idRole);
 
-      expect(mockRepository.delete).toHaveBeenCalledWith({ uuidRole: mockRole.uuidRole });
+      expect(mockRepository.delete).toHaveBeenCalledWith({ idRole: mockRole.idRole });
     });
 
     it('devrait lancer une erreur si le rôle à supprimer n\'existe pas', async () => {

--- a/src/roles/roles.service.ts
+++ b/src/roles/roles.service.ts
@@ -27,7 +27,7 @@ export class RolesService {
       return savedRole;
     } catch (error) {
       if (error.code === '23505') { // Code PostgreSQL pour violation de contrainte unique
-        throw new BadRequestException('Un rôle avec cet UUID existe déjà');
+        throw new BadRequestException('Un rôle avec cet id existe déjà');
       }
       throw new BadRequestException('Erreur lors de la création du rôle: ' + error.message);
     }
@@ -42,12 +42,12 @@ export class RolesService {
     }
   }
 
-  // Récupérer un rôle par son uuid
-  async findOne(uuidRole: string): Promise<Role> {
+  // Récupérer un rôle par son id
+  async findOne(idRole: string): Promise<Role> {
     try {
-      const role = await this.roleRepository.findOneBy({ uuidRole });
+      const role = await this.roleRepository.findOneBy({ idRole });
       if (!role) {
-        throw new NotFoundException(`Rôle avec l'UUID ${uuidRole} non trouvé`);
+        throw new NotFoundException(`Rôle avec l'id ${idRole} non trouvé`);
       }
       return role;
     } catch (error) {
@@ -59,9 +59,9 @@ export class RolesService {
   }
 
   // Mettre à jour un rôle
-  async update(uuidRole: string, updateRoleDto: UpdateRoleDto): Promise<Role> {
+  async update(idRole: string, updateRoleDto: UpdateRoleDto): Promise<Role> {
     try {
-      const role = await this.findOne(uuidRole);
+      const role = await this.findOne(idRole);
       Object.assign(role, updateRoleDto);
       return await this.roleRepository.save(role);
     } catch (error) {
@@ -73,11 +73,11 @@ export class RolesService {
   }
 
   // Supprimer un rôle
-  async remove(uuidRole: string): Promise<void> {
+  async remove(idRole: string): Promise<void> {
     try {
-      const result = await this.roleRepository.delete({ uuidRole });
+      const result = await this.roleRepository.delete({ idRole });
       if (result.affected === 0) {
-        throw new NotFoundException(`Rôle avec l'UUID ${uuidRole} non trouvé`);
+        throw new NotFoundException(`Rôle avec l'id ${idRole} non trouvé`);
       }
     } catch (error) {
       if (error instanceof NotFoundException) {

--- a/src/signature/dto/promotion-signature.dto.ts
+++ b/src/signature/dto/promotion-signature.dto.ts
@@ -51,9 +51,9 @@ export class MembreDto {
 export class PromotionSignatureDto {
   @ApiProperty({ 
     example: '123e4567-e89b-12d3-a456-426614174000', 
-    description: 'Identifiant unique (UUID) de la promotion'
+    description: 'Identifiant unique (id) de la promotion'
   })
-  uuid: string;
+  idPromotion: string;
 
   @ApiProperty({ 
     example: 'Développeur Web 2024', 

--- a/src/signature/signature.controller.spec.ts
+++ b/src/signature/signature.controller.spec.ts
@@ -44,7 +44,7 @@ describe('SignatureController', () => {
       const mockData = {
         promotions: [
           {
-            uuid: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            idPromotion: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
             nom: 'Cda P4 Vals',
             channel: {
               snowflake: '1344640530763485265',
@@ -68,7 +68,7 @@ describe('SignatureController', () => {
             apprenants: []
           },
           {
-            uuid: 'c9bf9e57-1685-4c89-bafb-ff5af830be8a',
+            idPromotion: 'c9bf9e57-1685-4c89-bafb-ff5af830be8a',
             nom: 'Promo PHP P2',
             channel: {
               snowflake: '1344611862003712050',
@@ -97,18 +97,18 @@ describe('SignatureController', () => {
       // Vérifier que le résultat correspond aux données de test
       expect(result).toEqual(mockData);
       expect(result.promotions.length).toBe(2);
-      expect(result.promotions[0].uuid).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
-      expect(result.promotions[1].uuid).toBe('c9bf9e57-1685-4c89-bafb-ff5af830be8a');
+      expect(result.promotions[0].idPromotion).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+      expect(result.promotions[1].idPromotion).toBe('c9bf9e57-1685-4c89-bafb-ff5af830be8a');
     });
   });
 
   describe('getPromotionSignature', () => {
     it('should return promotion signature for valid UUID', async () => {
       // Données de test
-      const uuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+      const idPromotion = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
       const mockData = {
         promotion: {
-          uuid,
+          idPromotion,
           nom: 'Cda P4 Vals',
           channel: {
             snowflake: '1344640530763485265',
@@ -167,18 +167,18 @@ describe('SignatureController', () => {
       mockSignatureService.getPromotionSignature.mockResolvedValue(mockData);
 
       // Appeler la méthode du contrôleur
-      const result = await controller.getPromotionSignature(uuid);
+      const result = await controller.getPromotionSignature(idPromotion);
 
-      // Vérifier que le service a été appelé avec le bon UUID
-      expect(mockSignatureService.getPromotionSignature).toHaveBeenCalledWith(uuid);
+      // Vérifier que le service a été appelé avec le bon id
+      expect(mockSignatureService.getPromotionSignature).toHaveBeenCalledWith(idPromotion);
       
       // Vérifier que le résultat correspond aux données de test
       expect(result).toEqual(mockData);
-      expect(result.promotion.uuid).toBe(uuid);
+      expect(result.idPromotion).toBe(idPromotion);
     });
 
     it('should throw NotFoundException for invalid UUID', async () => {
-      const uuid = 'invalid-uuid';
+      const idPromotion = 'invalid-uuid';
       
       // Configurer le mock pour rejeter avec une erreur
       mockSignatureService.getPromotionSignature.mockRejectedValue(
@@ -186,10 +186,10 @@ describe('SignatureController', () => {
       );
       
       // Vérifier que la méthode rejette une erreur
-      await expect(controller.getPromotionSignature(uuid)).rejects.toThrow();
+      await expect(controller.getPromotionSignature(idPromotion)).rejects.toThrow();
       
-      // Vérifier que le service a été appelé avec le bon UUID
-      expect(mockSignatureService.getPromotionSignature).toHaveBeenCalledWith(uuid);
+      // Vérifier que le service a été appelé avec le bon id
+      expect(mockSignatureService.getPromotionSignature).toHaveBeenCalledWith(idPromotion);
     });
   });
 
@@ -199,7 +199,7 @@ describe('SignatureController', () => {
       const mockData = {
         promotions: [
           {
-            uuid: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+            idPromotion: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
             nom: 'Cda P4 Vals',
             channel: {
               snowflake: '1344640530763485265',

--- a/src/signature/signature.controller.ts
+++ b/src/signature/signature.controller.ts
@@ -22,14 +22,14 @@ export class SignatureController {
     return this.signatureService.getAllPromotions();
   }
 
-  @Get('promotions/:uuid')
+  @Get('promotions/:id')
   @ApiOperation({ 
-    summary: 'Get a promotion signature by UUID',
+    summary: 'Get a promotion signature by id',
     description: 'Returns complete signature information for a promotion, including members and associated forum'
   })
   @ApiParam({ 
-    name: 'uuid', 
-    description: 'Unique identifier (UUID) of the promotion',
+    name: 'id', 
+    description: 'Unique identifier (id) of the promotion',
     type: 'string',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
@@ -42,8 +42,8 @@ export class SignatureController {
     status: HttpStatus.NOT_FOUND, 
     description: 'Promotion not found'
   })
-  async getPromotionSignature(@Param('uuid', ParseUUIDPipe) uuid: string): Promise<PromotionSignatureDto> {
-    return this.signatureService.getPromotionSignature(uuid);
+  async getPromotionSignature(@Param('idPromotion', ParseUUIDPipe) idPromotion: string): Promise<PromotionSignatureDto> {
+    return this.signatureService.getPromotionSignature(idPromotion);
   }
 
   @Post('promotions/test-data')

--- a/src/signature/signature.service.spec.ts
+++ b/src/signature/signature.service.spec.ts
@@ -64,7 +64,7 @@ describe('SignatureService', () => {
       
       // Vérifier que toutes les promotions ont la structure correcte
       for (const promotion of result.promotions) {
-        expect(promotion).toHaveProperty('uuid');
+        expect(promotion).toHaveProperty('idPromotion');
         expect(promotion).toHaveProperty('nom');
         expect(promotion).toHaveProperty('channel');
         expect(promotion).toHaveProperty('chargeDeProjet');
@@ -97,7 +97,7 @@ describe('SignatureService', () => {
       
       // Vérifier la structure de la première promotion
       const promotion = result.promotions[0];
-      expect(promotion).toHaveProperty('uuid');
+      expect(promotion).toHaveProperty('idPromotion');
       expect(promotion).toHaveProperty('nom');
       expect(promotion).toHaveProperty('channel');
       expect(promotion).toHaveProperty('chargeDeProjet');
@@ -105,7 +105,7 @@ describe('SignatureService', () => {
       expect(promotion).toHaveProperty('apprenants');
       
       // Vérifier le contenu des données de test
-      expect(promotion.uuid).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
+      expect(promotion.idPromotion).toBe('f47ac10b-58cc-4372-a567-0e02b2c3d479');
       expect(promotion.nom).toBe('Cda P4 Vals');
       
       // Vérifier la structure du channel
@@ -137,21 +137,19 @@ describe('SignatureService', () => {
   });
 
   describe('getPromotionSignature', () => {
-    it('should return promotion signature for valid UUID', async () => {
-      const uuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
-      const result = await service.getPromotionSignature(uuid);
+    it('should return promotion signature for valid id', async () => {
+      const idPromotion = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+      const result = await service.getPromotionSignature(idPromotion);
       
-      expect(result).toHaveProperty('promotion');
-      expect(result.promotion).toHaveProperty('uuid');
-      expect(result.promotion.uuid).toBe(uuid);
-      expect(result.promotion).toHaveProperty('channel');
-      expect(result.promotion.channel).toHaveProperty('snowflake');
+      expect(result).toHaveProperty('idPromotion');
+      expect(result).toHaveProperty('channel');
+      expect(result.channel).toHaveProperty('idChannel');
     });
 
-    it('should throw an error for invalid UUID', async () => {
-      const uuid = 'invalid-uuid';
+    it('should throw an error for invalid id', async () => {
+      const idPromotion = 'invalid-id';
       
-      await expect(service.getPromotionSignature(uuid)).rejects.toThrow();
+      await expect(service.getPromotionSignature(idPromotion)).rejects.toThrow();
     });
   });
 }); 

--- a/src/signature/signature.service.ts
+++ b/src/signature/signature.service.ts
@@ -66,16 +66,16 @@ export class SignatureService {
   }
 
   /**
-   * Récupère une promotion spécifique par son UUID
+   * Récupère une promotion spécifique par son id
    */
-  async getPromotionSignature(uuid: string): Promise<PromotionSignatureDto> {
+  async getPromotionSignature(idPromotion: string): Promise<PromotionSignatureDto> {
     const promotion = await this.promotionRepository.findOne({
-      where: { uuid },
+      where: { idPromotion },
       relations: ['category', 'followers', 'managers', 'role'],
     });
 
     if (!promotion) {
-      throw new Error(`Promotion with UUID ${uuid} not found`);
+      throw new Error(`Promotion with id ${idPromotion} not found`);
     }
 
     return this.mapPromotionToDto(promotion);
@@ -118,7 +118,7 @@ export class SignatureService {
     // Créer un DTO pour le channel/forum (s'il existe)
     const channel = promotion.category ? 
       { 
-        snowflake: promotion.category.uuid, 
+        snowflake: promotion.category.idCategory, 
         nom: promotion.category.name 
       } : 
       { 
@@ -128,27 +128,27 @@ export class SignatureService {
 
     // Créer un objet chargeDeProjet par défaut si aucun n'existe
     const defaultChargeDeProjet: MembreDto = {
-      snowflake: projectManager?.uuidDiscord || "000000000000000000",
+      snowflake: projectManager?.idDiscord || "000000000000000000",
       nom: projectManager?.guildUsername || "Chargé de projet non assigné",
       roles: defaultRoles('cdp', promotion.name)
     };
 
     return {
-      uuid: promotion.uuid,
+      idPromotion: promotion.idPromotion,
       nom: promotion.name,
       channel,
       chargeDeProjet: projectManager ? {
-        snowflake: projectManager.uuidDiscord,
+        snowflake: projectManager.idDiscord,
         nom: projectManager.guildUsername,
         roles: defaultRoles('cdp', promotion.name)
       } : defaultChargeDeProjet,
       formateurs: trainers.map(trainer => ({
-        snowflake: trainer.uuidDiscord,
+        snowflake: trainer.idDiscord,
         nom: trainer.guildUsername,
         roles: defaultRoles('formateur', promotion.name)
       })),
       apprenants: learners.map(learner => ({
-        snowflake: learner.uuidDiscord,
+        snowflake: learner.idDiscord,
         nom: learner.guildUsername,
         roles: defaultRoles('apprenant', promotion.name)
       }))
@@ -161,7 +161,7 @@ export class SignatureService {
   async generateTestPromotionSignature(): Promise<{ promotions: PromotionSignatureDto[] }> {
     const testData: PromotionSignatureDto[] = [
       {
-        uuid: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
+        idPromotion: 'f47ac10b-58cc-4372-a567-0e02b2c3d479',
         nom: 'Cda P4 Vals',
         channel: {
           snowflake: '1344640530763485265',
@@ -271,7 +271,7 @@ export class SignatureService {
         ]
       },
       {
-        uuid: 'c9bf9e57-1685-4c89-bafb-ff5af830be8a',
+        idPromotion: 'c9bf9e57-1685-4c89-bafb-ff5af830be8a',
         nom: 'Promo PHP P2',
         channel: {
           snowflake: '1344611862003712050',
@@ -379,7 +379,7 @@ export class SignatureService {
       if (!existingGuild) {
         this.logger.log('Creating test guild...');
         await this.guildsService.create({
-          uuid: guildId,
+          idGuild: guildId,
           name: 'Test Discord Server',
           memberCount: '50', // Required field in Guild entity
           configuration: {
@@ -392,101 +392,100 @@ export class SignatureService {
       // 1. Créer des catégories
       const categoryUuid = '123456789012345678';
       let category1 = await this.categoryRepository.findOne({
-        where: { uuid: categoryUuid }
+        where: { idCategory: categoryUuid }
       });
       
       if (!category1) {
         category1 = await this.categoryRepository.save({
-          uuid: categoryUuid,
+          idCategory: categoryUuid,
           name: 'Formation Dev Web',
           position: 1,
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       // 2. Créer des rôles s'ils n'existent pas déjà
       const rolePromotionUuid = '111222333444555666';
       let rolePromotion = await this.roleRepository.findOne({
-        where: { uuidRole: rolePromotionUuid }
+        where: { idRole: rolePromotionUuid }
       });
       
       if (!rolePromotion) {
         rolePromotion = await this.roleRepository.save({
-          uuidRole: rolePromotionUuid,
+          idRole: rolePromotionUuid,
           name: 'Promotion Dev Web 2024',
           memberCount: 25,
           rolePosition: 3,
           hoist: true,
           color: '#FF5733',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       const roleLearnerUuid = '222333444555666777';
       let roleLearner = await this.roleRepository.findOne({
-        where: { uuidRole: roleLearnerUuid }
+        where: { idRole: roleLearnerUuid }
       });
       
       if (!roleLearner) {
         roleLearner = await this.roleRepository.save({
-          uuidRole: roleLearnerUuid,
+          idRole: roleLearnerUuid,
           name: 'Apprenant',
           memberCount: 20,
           rolePosition: 2,
           hoist: true,
           color: '#33FF57',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       const roleTrainerUuid = '333444555666777888';
       let roleTrainer = await this.roleRepository.findOne({
-        where: { uuidRole: roleTrainerUuid }
+        where: { idRole: roleTrainerUuid }
       });
       
       if (!roleTrainer) {
         roleTrainer = await this.roleRepository.save({
-          uuidRole: roleTrainerUuid,
+          idRole: roleTrainerUuid,
           name: 'Formateur',
           memberCount: 3,
           rolePosition: 4,
           hoist: true,
           color: '#5733FF',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       const rolePMUuid = '444555666777888999';
       let rolePM = await this.roleRepository.findOne({
-        where: { uuidRole: rolePMUuid }
+        where: { idRole: rolePMUuid }
       });
       
       if (!rolePM) {
         rolePM = await this.roleRepository.save({
-          uuidRole: rolePMUuid,
+          idRole: rolePMUuid,
           name: 'Chef de Projet',
           memberCount: 1,
           rolePosition: 5,
           hoist: true,
           color: '#33FFFF',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       // 3. Créer des channels (forums) s'ils n'existent pas déjà
       const forumChannelUuid = '555666777888999000';
       let forumChannel = await this.channelRepository.findOne({
-        where: { uuid: forumChannelUuid }
+        where: { idCategory: forumChannelUuid }
       });
       
       if (!forumChannel) {
         forumChannel = await this.channelRepository.save({
-          uuid: forumChannelUuid,
+          idCategory: forumChannelUuid,
           name: 'forum-dev-web',
           type: 'GUILD_FORUM',
           channelPosition: 1,
-          uuidCategory: category1.uuid,
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
@@ -494,12 +493,12 @@ export class SignatureService {
       // Project Manager Discord User
       const pmDiscordId = '900000000000000001';
       let pmDiscordUser = await this.discordUserRepository.findOne({
-        where: { uuidDiscord: pmDiscordId }
+        where: { idDiscord: pmDiscordId }
       });
       
       if (!pmDiscordUser) {
         pmDiscordUser = await this.discordUserRepository.save({
-          uuidDiscord: pmDiscordId,
+          idDiscord: pmDiscordId,
           discordUsername: 'pm_user',
           discriminator: '0001'
         });
@@ -510,12 +509,12 @@ export class SignatureService {
       for (let i = 1; i <= 3; i++) {
         const discordId = `91000000000000000${i}`;
         let trainerDiscordUser = await this.discordUserRepository.findOne({
-          where: { uuidDiscord: discordId }
+          where: { idDiscord: discordId }
         });
         
         if (!trainerDiscordUser) {
           trainerDiscordUser = await this.discordUserRepository.save({
-            uuidDiscord: discordId,
+            idDiscord: discordId,
             discordUsername: `trainer${i}`,
             discriminator: `100${i}`
           });
@@ -528,12 +527,12 @@ export class SignatureService {
       for (let i = 1; i <= 15; i++) {
         const discordId = `92000000000000000${i}`.substring(0, 19);
         let learnerDiscordUser = await this.discordUserRepository.findOne({
-          where: { uuidDiscord: discordId }
+          where: { idDiscord: discordId }
         });
         
         if (!learnerDiscordUser) {
           learnerDiscordUser = await this.discordUserRepository.save({
-            uuidDiscord: discordId,
+            idDiscord: discordId,
             discordUsername: `learner${i}`,
             discriminator: `200${i < 10 ? '0' + i : i}`
           });
@@ -545,19 +544,19 @@ export class SignatureService {
       // Project Manager
       let projectManager;
       const existingPMMember = await this.memberRepository.findOne({
-        where: { uuidDiscord: pmDiscordId }
+        where: { idDiscord: pmDiscordId }
       });
       
       if (!existingPMMember) {
         projectManager = await this.memberRepository.save({
-          uuidMember: uuidv4(),
+          idMember: uuidv4(),
           guildUsername: 'pm_user',
           xp: '2500',
           level: 5,
           communityRole: 'ProjectManager',
           status: 'Active',
-          uuidGuild: guildId,
-          uuidDiscord: pmDiscordId
+          idGuild: guildId,
+          idDiscord: pmDiscordId
         });
       } else {
         projectManager = existingPMMember;
@@ -570,19 +569,19 @@ export class SignatureService {
         let trainer;
         
         const existingTrainer = await this.memberRepository.findOne({
-          where: { uuidDiscord: discordId }
+          where: { idDiscord: discordId }
         });
         
         if (!existingTrainer) {
           trainer = await this.memberRepository.save({
-            uuidMember: uuidv4(),
+            idMember: uuidv4(),
             guildUsername: `trainer${i}`,
             xp: `${1500 + (i * 100)}`,
             level: 4,
             communityRole: 'Trainer',
             status: 'Active',
-            uuidGuild: guildId,
-            uuidDiscord: discordId
+            idGuild: guildId,
+            idDiscord: discordId
           });
         } else {
           trainer = existingTrainer;
@@ -598,19 +597,19 @@ export class SignatureService {
         let learner;
         
         const existingLearner = await this.memberRepository.findOne({
-          where: { uuidDiscord: discordId }
+          where: { idDiscord: discordId }
         });
         
         if (!existingLearner) {
           learner = await this.memberRepository.save({
-            uuidMember: uuidv4(),
+            idMember: uuidv4(),
             guildUsername: `learner${i}`,
             xp: `${500 + (i * 50)}`,
             level: 2,
             communityRole: 'Learner',
             status: 'Active',
-            uuidGuild: guildId,
-            uuidDiscord: discordId
+            idGuild: guildId,
+            idDiscord: discordId
           });
         } else {
           learner = existingLearner;
@@ -632,8 +631,8 @@ export class SignatureService {
         course = await this.courseRepository.save({
           name: 'Développeur Web',
           isCertified: true,
-          uuidGuild: guildId,
-          uuidCategory: category1.uuid
+          idGuild: guildId,
+          idCategory: category1.idCategory
         });
       } else {
         course = existingCourse;
@@ -645,20 +644,20 @@ export class SignatureService {
       
       // Vérifier si la promotion existe déjà
       const existingPromotion = await this.promotionRepository.findOne({
-        where: { name: promotionName }
+        where: { idPromotion: uuidv4() }
       });
       
       if (!existingPromotion) {
         promotion = new Promotion();
-        promotion.uuid = uuidv4();
+        promotion.idPromotion = uuidv4();
         promotion.name = promotionName;
         promotion.startDate = new Date('2024-01-15');
         promotion.endDate = new Date('2024-12-15');
         promotion.status = 'active';
-        promotion.uuidCourse = course.uuid;
-        promotion.uuidGuild = guildId;
-        promotion.uuidRole = rolePromotion.uuidRole;
-        promotion.uuidCategory = category1.uuid;
+        promotion.idCourse = course.idPromotion;
+        promotion.idGuild = guildId;
+        promotion.idRole = rolePromotion.idRole;
+        promotion.idCategory = category1.idCategory;
         
         // Sauvegarder la promotion
         promotion = await this.promotionRepository.save(promotion);
@@ -669,7 +668,7 @@ export class SignatureService {
       // 6. Établir les relations entre promotion et membres
       // Ajouter les followers (learners)
       const promotionWithFollowers = await this.promotionRepository.findOne({
-        where: { uuid: promotion.uuid },
+        where: { idPromotion: promotion.idPromotion },
         relations: ['followers'],
       });
       
@@ -683,7 +682,7 @@ export class SignatureService {
       
       // Ajouter les managers (PM et trainers)
       const promotionWithManagers = await this.promotionRepository.findOne({
-        where: { uuid: promotion.uuid },
+        where: { idPromotion: promotion.idPromotion },
         relations: ['managers'],
       });
       
@@ -699,7 +698,7 @@ export class SignatureService {
       
       // Récupérer la promotion complète avec toutes les relations
       const result = await this.promotionRepository.findOne({
-        where: { uuid: promotion.uuid },
+        where: { idPromotion: promotion.idPromotion },
         relations: ['category', 'followers', 'managers', 'role'],
       });
       
@@ -735,7 +734,7 @@ export class SignatureService {
       if (!existingGuild) {
         this.logger.log('Creating guild for specific promotion...');
         await this.guildsService.create({
-          uuid: guildId,
+          idGuild: guildId,
           name: 'Test Discord Server',
           memberCount: '50',
           configuration: {
@@ -748,15 +747,15 @@ export class SignatureService {
       // 1. Créer/récupérer la catégorie
       const categoryUuid = '1344640530763485265';
       let category = await this.categoryRepository.findOne({
-        where: { uuid: categoryUuid }
+        where: { idCategory: categoryUuid }
       });
       
       if (!category) {
         category = await this.categoryRepository.save({
-          uuid: categoryUuid,
+          idCategory: categoryUuid,
           name: 'Forum de la Cda P4 Vals',
           position: 1,
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
@@ -764,89 +763,88 @@ export class SignatureService {
       // Rôle CDP
       const roleCdpUuid = '1344616774402052127';
       let roleCdp = await this.roleRepository.findOne({
-        where: { uuidRole: roleCdpUuid }
+        where: { idRole: roleCdpUuid }
       });
       
       if (!roleCdp) {
         roleCdp = await this.roleRepository.save({
-          uuidRole: roleCdpUuid,
+          idRole: roleCdpUuid,
           name: 'cdp',
           memberCount: 1,
           rolePosition: 5,
           hoist: true,
           color: '#33FFFF',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       // Rôle promotion
       const rolePromoUuid = '1344616774402052128';
       let rolePromo = await this.roleRepository.findOne({
-        where: { uuidRole: rolePromoUuid }
+        where: { idRole: rolePromoUuid }
       });
       
       if (!rolePromo) {
         rolePromo = await this.roleRepository.save({
-          uuidRole: rolePromoUuid,
+          idRole: rolePromoUuid,
           name: 'cda-p4-vals',
           memberCount: 10,
           rolePosition: 3,
           hoist: true,
           color: '#FF5733',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       // Rôle formateur
       const roleFormateurUuid = '1344616774402052129';
       let roleFormateur = await this.roleRepository.findOne({
-        where: { uuidRole: roleFormateurUuid }
+        where: { idRole: roleFormateurUuid }
       });
       
       if (!roleFormateur) {
         roleFormateur = await this.roleRepository.save({
-          uuidRole: roleFormateurUuid,
+          idRole: roleFormateurUuid,
           name: 'formateur',
           memberCount: 2,
           rolePosition: 4,
           hoist: true,
           color: '#5733FF',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       // Rôle apprenant
       const roleApprenantUuid = '1344616774402052126';
       let roleApprenant = await this.roleRepository.findOne({
-        where: { uuidRole: roleApprenantUuid }
+        where: { idRole: roleApprenantUuid }
       });
       
       if (!roleApprenant) {
         roleApprenant = await this.roleRepository.save({
-          uuidRole: roleApprenantUuid,
+          idRole: roleApprenantUuid,
           name: 'apprenant',
           memberCount: 5,
           rolePosition: 2,
           hoist: true,
           color: '#33FF57',
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
       // 3. Créer/récupérer le forum
       const forumChannelUuid = '1344640530763485265';
       let forumChannel = await this.channelRepository.findOne({
-        where: { uuid: forumChannelUuid }
+        where: { idCategory: forumChannelUuid }
       });
       
       if (!forumChannel) {
         forumChannel = await this.channelRepository.save({
-          uuid: forumChannelUuid,
+          idCategory: forumChannelUuid,
           name: 'Forum de la Cda P4 Vals',
           type: 'GUILD_FORUM',
           channelPosition: 1,
-          uuidCategory: category.uuid,
-          uuidGuild: guildId
+          idGuild: guildId
         });
       }
       
@@ -854,12 +852,12 @@ export class SignatureService {
       // Chargé de projet
       const cdpDiscordId = '987654321098765432';
       let cdpDiscordUser = await this.discordUserRepository.findOne({
-        where: { uuidDiscord: cdpDiscordId }
+        where: { idDiscord: cdpDiscordId }
       });
       
       if (!cdpDiscordUser) {
         cdpDiscordUser = await this.discordUserRepository.save({
-          uuidDiscord: cdpDiscordId,
+          idDiscord: cdpDiscordId,
           discordUsername: 'Jean Dupont',
           discriminator: '0001'
         });
@@ -874,12 +872,12 @@ export class SignatureService {
         const name = trainerNames[i];
         
         let trainerDiscordUser = await this.discordUserRepository.findOne({
-          where: { uuidDiscord: discordId }
+          where: { idDiscord: discordId }
         });
         
         if (!trainerDiscordUser) {
           trainerDiscordUser = await this.discordUserRepository.save({
-            uuidDiscord: discordId,
+            idDiscord: discordId,
             discordUsername: name,
             discriminator: `100${i+1}`
           });
@@ -909,12 +907,12 @@ export class SignatureService {
         
         // Vérifie si l'utilisateur existe déjà (pour Yohan notamment)
         let learnerDiscordUser = await this.discordUserRepository.findOne({
-          where: { uuidDiscord: discordId }
+          where: { idDiscord: discordId }
         });
         
         if (!learnerDiscordUser) {
           learnerDiscordUser = await this.discordUserRepository.save({
-            uuidDiscord: discordId,
+            idDiscord: discordId,
             discordUsername: name,
             discriminator: `200${i+1}`
           });
@@ -925,19 +923,19 @@ export class SignatureService {
       // Chargé de projet
       let projectManager;
       const existingPMMember = await this.memberRepository.findOne({
-        where: { uuidDiscord: cdpDiscordId }
+        where: { idDiscord: cdpDiscordId }
       });
       
       if (!existingPMMember) {
         projectManager = await this.memberRepository.save({
-          uuidMember: uuidv4(),
+          idMember: uuidv4(),
           guildUsername: 'Jean Dupont',
           xp: '2500',
           level: 5,
           communityRole: 'ProjectManager',
           status: 'Active',
-          uuidGuild: guildId,
-          uuidDiscord: cdpDiscordId
+          idGuild: guildId,
+          idDiscord: cdpDiscordId
         });
       } else {
         projectManager = existingPMMember;
@@ -952,7 +950,7 @@ export class SignatureService {
         // Pour Yohan qui a un double rôle (formateur et apprenant)
         if (discordId === '223812446312202251') {
           let yohanMember = await this.memberRepository.findOne({
-            where: { uuidDiscord: discordId }
+            where: { idDiscord: discordId }
           });
           
           if (yohanMember) {
@@ -965,14 +963,14 @@ export class SignatureService {
           } else {
             // S'il n'existe pas, le créer comme formateur
             const trainer = await this.memberRepository.save({
-              uuidMember: uuidv4(),
+              idMember: uuidv4(),
               guildUsername: name,
               xp: '2000',
               level: 4,
               communityRole: 'Trainer', // On le crée d'abord comme formateur
               status: 'Active',
-              uuidGuild: guildId,
-              uuidDiscord: discordId
+              idGuild: guildId,
+              idDiscord: discordId
             });
             trainers.push(trainer);
           }
@@ -980,19 +978,19 @@ export class SignatureService {
           // Autres formateurs (pas Yohan)
           let trainer;
           const existingTrainer = await this.memberRepository.findOne({
-            where: { uuidDiscord: discordId }
+            where: { idDiscord: discordId }
           });
           
           if (!existingTrainer) {
             trainer = await this.memberRepository.save({
-              uuidMember: uuidv4(),
+              idMember: uuidv4(),
               guildUsername: name,
               xp: `${1500 + (i * 100)}`,
               level: 4,
               communityRole: 'Trainer',
               status: 'Active',
-              uuidGuild: guildId,
-              uuidDiscord: discordId
+              idGuild: guildId,
+              idDiscord: discordId
             });
           } else {
             trainer = existingTrainer;
@@ -1011,7 +1009,7 @@ export class SignatureService {
         // Traitement spécial pour Yohan (qui est aussi formateur)
         if (discordId === '223812446312202251') {
           let yohanMember = await this.memberRepository.findOne({
-            where: { uuidDiscord: discordId }
+            where: { idDiscord: discordId }
           });
           
           if (yohanMember) {
@@ -1023,19 +1021,19 @@ export class SignatureService {
           // Autres apprenants
           let learner;
           const existingLearner = await this.memberRepository.findOne({
-            where: { uuidDiscord: discordId }
+            where: { idDiscord: discordId }
           });
           
           if (!existingLearner) {
             learner = await this.memberRepository.save({
-              uuidMember: uuidv4(),
+              idMember: uuidv4(),
               guildUsername: name,
               xp: `${500 + (i * 50)}`,
               level: 2,
               communityRole: 'Learner',
               status: 'Active',
-              uuidGuild: guildId,
-              uuidDiscord: discordId
+              idGuild: guildId,
+              idDiscord: discordId
             });
           } else {
             learner = existingLearner;
@@ -1057,8 +1055,8 @@ export class SignatureService {
         course = await this.courseRepository.save({
           name: 'Cda P4 Vals',
           isCertified: true,
-          uuidGuild: guildId,
-          uuidCategory: category.uuid
+          idGuild: guildId,
+          idCategory: category.idCategory
         });
       } else {
         course = existingCourse;
@@ -1066,24 +1064,24 @@ export class SignatureService {
       
       // 7. Créer/récupérer la promotion
       let promotion;
-      const promotionUuid = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+      const promotionId = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
       
       // Vérifier si la promotion existe déjà
       const existingPromotion = await this.promotionRepository.findOne({
-        where: { uuid: promotionUuid }
+        where: { idPromotion: promotionId }
       });
       
       if (!existingPromotion) {
         promotion = new Promotion();
-        promotion.uuid = promotionUuid;
+        promotion.idPromotion = uuidv4();
         promotion.name = 'Cda P4 Vals';
         promotion.startDate = new Date('2024-01-15');
         promotion.endDate = new Date('2024-12-15');
         promotion.status = 'active';
-        promotion.uuidCourse = course.uuid;
-        promotion.uuidGuild = guildId;
-        promotion.uuidRole = rolePromo.uuidRole;
-        promotion.uuidCategory = category.uuid;
+        promotion.idCourse = course.idPromotion;
+        promotion.idGuild = guildId;
+        promotion.idRole = rolePromo.idRole;
+        promotion.idCategory = category.idCategory;
         
         // Sauvegarder la promotion
         promotion = await this.promotionRepository.save(promotion);
@@ -1094,7 +1092,7 @@ export class SignatureService {
       // 8. Établir les relations entre promotion et membres
       // Ajouter les followers (learners)
       const promotionWithFollowers = await this.promotionRepository.findOne({
-        where: { uuid: promotion.uuid },
+        where: { idPromotion: promotion.idPromotion },
         relations: ['followers'],
       });
       
@@ -1106,7 +1104,7 @@ export class SignatureService {
       
       // Ajouter les managers (PM et trainers)
       const promotionWithManagers = await this.promotionRepository.findOne({
-        where: { uuid: promotion.uuid },
+        where: { idPromotion: promotion.idPromotion },
         relations: ['managers'],
       });
       
@@ -1120,7 +1118,7 @@ export class SignatureService {
       
       // Récupérer la promotion complète avec toutes les relations
       const result = await this.promotionRepository.findOne({
-        where: { uuid: promotion.uuid },
+        where: { idPromotion: promotion.idPromotion },
         relations: ['category', 'followers', 'managers', 'role'],
       });
       

--- a/src/tags/entities/tag.entity.ts
+++ b/src/tags/entities/tag.entity.ts
@@ -4,8 +4,8 @@ import { ApiProperty } from '@nestjs/swagger';
 @Entity('tags')
 export class Tag {
   @ApiProperty({ description: 'Identifiant unique du tag' })
-  @PrimaryGeneratedColumn('uuid')
-  uuid: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_tag' })
+  idTag: string;
 
   @ApiProperty({ description: 'Nom du tag' })
   @Column({ unique: true })

--- a/src/tags/tags.controller.ts
+++ b/src/tags/tags.controller.ts
@@ -19,7 +19,7 @@ export class TagsController {
     content: {
       'application/json': {
         example: {
-          uuid: '550e8400-e29b-41d4-a716-446655440000',
+          idTag: '550e8400-e29b-41d4-a716-446655440000',
           name: 'JavaScript',
           description: 'Langage de programmation pour le web',
           createdAt: '2024-03-14T12:00:00Z',
@@ -67,13 +67,13 @@ export class TagsController {
     content: {
       'application/json': {
         example: [{
-          uuid: '550e8400-e29b-41d4-a716-446655440000',
+          idTag: '550e8400-e29b-41d4-a716-446655440000',
           name: 'JavaScript',
           description: 'Langage de programmation pour le web',
           createdAt: '2024-03-14T12:00:00Z',
           updatedAt: '2024-03-14T12:00:00Z'
         }, {
-          uuid: '550e8400-e29b-41d4-a716-446655440001',
+          idTag: '550e8400-e29b-41d4-a716-446655440001',
           name: 'Python',
           description: 'Langage de programmation polyvalent',
           createdAt: '2024-03-14T12:00:00Z',
@@ -88,7 +88,7 @@ export class TagsController {
 
   @Get(':id')
   @ApiOperation({ summary: 'Récupérer un tag par son ID' })
-  @ApiParam({ name: 'id', description: 'UUID du tag', type: 'string' })
+  @ApiParam({ name: 'id', description: 'id du tag', type: 'string' })
   @ApiResponse({ 
     status: HttpStatus.OK, 
     description: 'Tag récupéré avec succès', 
@@ -96,7 +96,7 @@ export class TagsController {
     content: {
       'application/json': {
         example: {
-          uuid: '550e8400-e29b-41d4-a716-446655440000',
+          idTag: '550e8400-e29b-41d4-a716-446655440000',
           name: 'JavaScript',
           description: 'Langage de programmation pour le web',
           createdAt: '2024-03-14T12:00:00Z',
@@ -124,7 +124,7 @@ export class TagsController {
 
   @Patch(':id')
   @ApiOperation({ summary: 'Mettre à jour un tag' })
-  @ApiParam({ name: 'id', description: 'UUID du tag', type: 'string' })
+  @ApiParam({ name: 'id', description: 'id du tag', type: 'string' })
   @ApiResponse({ 
     status: HttpStatus.OK, 
     description: 'Tag mis à jour avec succès', 
@@ -132,7 +132,7 @@ export class TagsController {
     content: {
       'application/json': {
         example: {
-          uuid: '550e8400-e29b-41d4-a716-446655440000',
+          idTag: '550e8400-e29b-41d4-a716-446655440000',
           name: 'JavaScript ES2022',
           description: 'Dernière version du langage JavaScript',
           createdAt: '2024-03-14T12:00:00Z',
@@ -189,7 +189,7 @@ export class TagsController {
 
   @Delete(':id')
   @ApiOperation({ summary: 'Supprimer un tag' })
-  @ApiParam({ name: 'id', description: 'UUID du tag', type: 'string' })
+  @ApiParam({ name: 'id', description: 'id du tag', type: 'string' })
   @ApiResponse({ 
     status: HttpStatus.OK, 
     description: 'Tag supprimé avec succès',

--- a/src/tags/tags.service.spec.ts
+++ b/src/tags/tags.service.spec.ts
@@ -13,7 +13,7 @@ describe('TagsService', () => {
   let repository: Repository<Tag>;
 
   const mockTag = {
-    uuid: '123e4567-e89b-12d3-a456-426614174000',
+    idTag: '123e4567-e89b-12d3-a456-426614174000',
     name: 'Test Tag',
     description: 'Test Description',
     createdAt: new Date(),
@@ -88,14 +88,14 @@ describe('TagsService', () => {
   });
 
   describe('findOne', () => {
-    it('devrait retourner un tag par son uuid', async () => {
+    it('devrait retourner un tag par son id', async () => {
       mockRepository.findOne.mockResolvedValue(mockTag);
 
-      const result = await service.findOne(mockTag.uuid);
+      const result = await service.findOne(mockTag.idTag);
 
       expect(result).toEqual(mockTag);
       expect(mockRepository.findOne).toHaveBeenCalledWith({
-        where: { uuid: mockTag.uuid },
+        where: { idTag: mockTag.idTag },
       });
     });
 
@@ -115,7 +115,7 @@ describe('TagsService', () => {
       mockRepository.findOne.mockResolvedValue(mockTag);
       mockRepository.save.mockResolvedValue({ ...mockTag, ...updateTagDto });
 
-      const result = await service.update(mockTag.uuid, updateTagDto);
+      const result = await service.update(mockTag.idTag, updateTagDto);
 
       expect(result).toEqual({ ...mockTag, ...updateTagDto });
       expect(mockRepository.save).toHaveBeenCalled();
@@ -131,7 +131,7 @@ describe('TagsService', () => {
       mockRepository.findOne.mockResolvedValue(mockTag);
       mockRepository.save.mockRejectedValue({ code: '23505' });
 
-      await expect(service.update(mockTag.uuid, { name: 'Existing Tag' })).rejects.toThrow(ConflictException);
+      await expect(service.update(mockTag.idTag, { name: 'Existing Tag' })).rejects.toThrow(ConflictException);
     });
   });
 
@@ -139,9 +139,9 @@ describe('TagsService', () => {
     it('devrait supprimer un tag avec succès', async () => {
       mockRepository.delete.mockResolvedValue({ affected: 1 });
 
-      await service.remove(mockTag.uuid);
+      await service.remove(mockTag.idTag);
 
-      expect(mockRepository.delete).toHaveBeenCalledWith(mockTag.uuid);
+      expect(mockRepository.delete).toHaveBeenCalledWith(mockTag.idTag);
     });
 
     it('devrait lever une NotFoundException si le tag n\'existe pas', async () => {

--- a/src/tags/tags.service.ts
+++ b/src/tags/tags.service.ts
@@ -28,10 +28,10 @@ export class TagsService {
     return await this.tagRepository.find();
   }
 
-  async findOne(uuid: string): Promise<Tag> {
-    const tag = await this.tagRepository.findOne({ where: { uuid } });
+  async findOne(id: string): Promise<Tag> {
+    const tag = await this.tagRepository.findOne({ where: { idTag: id } });
     if (!tag) {
-      throw new NotFoundException(`Tag avec l'ID ${uuid} non trouvé`);
+      throw new NotFoundException(`Tag avec l'ID ${id} non trouvé`);
     }
     return tag;
   }

--- a/src/utils/pickable-discord-id-fields.ts
+++ b/src/utils/pickable-discord-id-fields.ts
@@ -1,19 +1,19 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsString, Length, Matches } from 'class-validator';
 
-export class PickableDiscordUUIDFields {
+export class PickableDiscordIdFields {
 
   @ApiProperty({
     description: 'Identifiant unique du compte discord du membre (Snowflake)',
     minLength: 17,
     maxLength: 19,
-    default: 'discord_user_uuid',
+    default: 'discord_user_id',
     example: '726798891974243359',
   })
   @IsString()
   @Matches(/^\d+$/)
   @Length(17, 19)
-  uuidDiscord: string;
+  idDiscord: string;
 
   @ApiProperty({
     description: 'Identifiant unique du serveur (Snowflake)',
@@ -24,7 +24,7 @@ export class PickableDiscordUUIDFields {
   @IsString()
   @Matches(/^\d+$/)
   @Length(17, 19)
-  uuidGuild: string;
+  idGuild: string;
 
   @ApiProperty({
     description: 'Identifiant unique de category (Snowflake)',
@@ -35,7 +35,7 @@ export class PickableDiscordUUIDFields {
   @IsString()
   @Matches(/^\d+$/)
   @Length(17, 19)
-  uuidCategory: string;
+  idCategory: string;
 
   @ApiProperty({
     description: 'Identifiant unique de channel (Snowflake)',
@@ -46,7 +46,7 @@ export class PickableDiscordUUIDFields {
   @IsString()
   @Matches(/^\d+$/)
   @Length(17, 19)
-  uuidChannel: string;
+  idChannel: string;
 
   @ApiProperty({
     description: 'Identifiant unique de rôle (Snowflake)',
@@ -57,7 +57,7 @@ export class PickableDiscordUUIDFields {
   @IsString()
   @Matches(/^\d+$/)
   @Length(17, 19)
-  uuidRole: string;
+  idRole: string;
 
   @ApiProperty({
     description: 'Identifiant unique du tag (Snowflake)',
@@ -68,6 +68,38 @@ export class PickableDiscordUUIDFields {
   @IsString()
   @Matches(/^\d+$/)
   @Length(17, 19)
-  uuidTag: string;
+  idTag: string;
 
+  @ApiProperty({
+    description: 'Identifiant unique de la formation (Snowflake)',
+    minLength: 17,
+    maxLength: 19,
+    example: '726798891974243359',
+  })
+  @IsString()
+  @Matches(/^\d+$/)
+  @Length(17, 19)
+  idCourse: string;
+
+  @ApiProperty({
+    description: 'Identifiant unique du campus',
+    minLength: 17,
+    maxLength: 19,
+    example: '726798891974243359',
+  })
+  @IsString()
+  @Matches(/^\d+$/)
+  @Length(17, 19)
+  idCampus: string;
+
+  @ApiProperty({
+    description: 'Identifiant unique de la promotion',
+    minLength: 17,
+    maxLength: 19,
+    example: '726798891974243359',
+  })
+  @IsString()
+  @Matches(/^\d+$/)
+  @Length(17, 19)
+  idPromotion: string;
 }

--- a/src/utils/pickable-dto-fields.ts
+++ b/src/utils/pickable-dto-fields.ts
@@ -1,8 +1,7 @@
 import { ApiProperty } from '@nestjs/swagger';
-import { IsString, Length } from 'class-validator';
+import { IsString, Length, MaxLength } from 'class-validator';
 
 export class PickableDtoFields {
-
     @ApiProperty({
         description: 'Nom de la ressource',
         example: 'Idetaka',
@@ -12,4 +11,29 @@ export class PickableDtoFields {
     @Length(2, 50)
     name: string;
 
+    @ApiProperty({
+        description: 'Email de l\'utilisateur',
+        example: 'user@example.com',
+      })
+      @IsString()
+      @MaxLength(255)
+    email: string;
+
+    @ApiProperty({
+        description: 'Prénom de l\'utilisateur',
+        example: 'Jean',
+        maxLength: 50
+    })
+    @IsString()
+    @Length(2, 50)
+    firstName: string;
+
+    @ApiProperty({
+        description: 'Nom de famille de l\'utilisateur',
+        example: 'Dupont',
+        maxLength: 50
+    })
+    @IsString()
+    @Length(2, 50)
+    lastName: string;
 }

--- a/src/utils/pickable-intern-id-fields.ts
+++ b/src/utils/pickable-intern-id-fields.ts
@@ -1,160 +1,146 @@
 import { ApiProperty } from '@nestjs/swagger';
 import { IsUUID } from 'class-validator';
 
-export class PickableInternUUIDFields {
+export class PickableInternIdFields {
 
   @ApiProperty({
     description: 'Identifiant unique du membre',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })  
   @IsUUID()
-  uuidMember: string;
+  idMember: string;
 
   @ApiProperty({
     description: 'Identifiant unique des informations du membre',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidMemberInfos: string;
+  idMemberInfos: string;
 
   @ApiProperty({
     description: 'Identifiant unique du compte du dashboard',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidDashboardAccount: string;
+  idDashboardAccount: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la demande d\'identification',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidIdentificationRequest: string;
+  idIdentificationRequest: string;
 
   @ApiProperty({
     description: 'Identifiant unique du template de serveur',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidGuildTemplate: string;
-
-  @ApiProperty({
-    description: 'Identifiant unique du campus',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
-  @IsUUID()
-  uuidCampus: string;
-
-  @ApiProperty({
-    description: 'Identifiant unique de la formation',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
-  @IsUUID()
-  uuidCourse: string;
-
-  @ApiProperty({
-    description: 'Identifiant unique de la promotion',
-    example: '123e4567-e89b-12d3-a456-426614174000',
-  })
-  @IsUUID()
-  uuidPromotion: string;
+  idGuildTemplate: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la ressource',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidResource: string;
+  idResource: string;
 
   @ApiProperty({
     description: 'Identifiant unique du commentaire',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidComment: string;
+  idComment: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la transaction',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidXpTransaction: string;
+  idXpTransaction: string;
 
   @ApiProperty({
     description: 'Identifiant unique du vote',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidVote: string;
+  idVote: string;
 
   @ApiProperty({
     description: 'Identifiant unique du rapport',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidReport: string;
+  idReport: string;
 
   @ApiProperty({
     description: 'Identifiant unique du membre qui a fait le signalement',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidReporter: string;
+  idReporter: string;
 
   @ApiProperty({
     description: 'Identifiant unique du membre signalé',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidReportedMember: string;
+  idReportedMember: string;
 
   @ApiProperty({
     description: 'Identifiant unique de l\'action de modération',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidModerationAction: string;
+  idModerationAction: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la question',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidQuestion: string;
+  idQuestion: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la question',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidQuestionTemplate: string;
+  idQuestionTemplate: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la résponse',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidAnswer: string;
+  idAnswer: string;
 
   @ApiProperty({
     description: 'Identifiant unique de la résponse',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidAnswerTemplate: string;
+  idAnswerTemplate: string;
 
   @ApiProperty({
     description: 'Identifiant unique du sondage',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidPoll: string;
+  idPoll: string;
 
   @ApiProperty({
     description: 'Identifiant unique du template du sondage',
     example: '123e4567-e89b-12d3-a456-426614174000',
   })
   @IsUUID()
-  uuidPollTemplate: string;
+  idPollTemplate: string;
+
+  @ApiProperty({
+    description: 'UUID de l\'objet référencé',
+    example: '123e4567-e89b-12d3-a456-426614174000',
+  })
+  @IsUUID()
+  idReference: string;
 
 }

--- a/src/votes/dto/create-vote.dto.ts
+++ b/src/votes/dto/create-vote.dto.ts
@@ -1,10 +1,10 @@
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { IsEnum, IsNotEmpty, IsUUID, ValidateIf } from 'class-validator';
 import { VoteType } from '../entities/vote.entity';
-import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from '../../utils/pickable-intern-id-fields';
 
-export class CreateVoteDto extends PickType(PickableInternUUIDFields, [
-  'uuidMember' // Pour le membre qui vote
+export class CreateVoteDto extends PickType(PickableInternIdFields, [
+  'idMember' // Pour le membre qui vote
 ]) {
   @ApiProperty({
     description: 'Type de vote (upvote ou downvote)',
@@ -20,18 +20,18 @@ export class CreateVoteDto extends PickType(PickableInternUUIDFields, [
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false
   })
-  @ValidateIf(o => !o.uuidComment)
+  @ValidateIf(o => !o.idComment)
   @IsUUID('4', { message: 'L\'UUID de la ressource doit être un UUID valide' })
   @IsNotEmpty({ message: 'L\'UUID de la ressource est requis si aucun commentaire n\'est spécifié' })
-  uuidResource?: string;
+  idResource?: string;
 
   @ApiProperty({
     description: 'UUID du commentaire voté (requis si le vote est sur un commentaire)',
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false
   })
-  @ValidateIf(o => !o.uuidResource)
+  @ValidateIf(o => !o.idResource)
   @IsUUID('4', { message: 'L\'UUID du commentaire doit être un UUID valide' })
   @IsNotEmpty({ message: 'L\'UUID du commentaire est requis si aucune ressource n\'est spécifiée' })
-  uuidComment?: string;
+  idComment?: string;
 }

--- a/src/votes/entities/vote.entity.ts
+++ b/src/votes/entities/vote.entity.ts
@@ -17,11 +17,11 @@ export enum VoteType {
 @Unique(['member', 'comment']) // Un membre ne peut voter qu'une fois pour un commentaire
 export class Vote {
   @ApiProperty({
-    description: 'UUID unique du vote',
+    description: 'id unique du vote',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_vote' })
-  uuidVote: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_vote' })
+  idVote: string;
 
   @ApiProperty({
     description: 'Type de vote (upvote ou downvote)',
@@ -54,7 +54,7 @@ export class Vote {
     type: () => Member
   })
   @ManyToOne(() => Member)
-  @JoinColumn({ name: 'uuid_member' })
+  @JoinColumn({ name: 'id_member' })
   member: Member;
 
   @ApiProperty({
@@ -63,7 +63,7 @@ export class Vote {
     required: false
   })
   @ManyToOne(() => Resource, resource => resource.votes, { nullable: true })
-  @JoinColumn({ name: 'uuid_resource' })
+  @JoinColumn({ name: 'id_resource' })
   resource?: Resource;
 
   @ApiProperty({
@@ -72,6 +72,6 @@ export class Vote {
     required: false
   })
   @ManyToOne(() => Comment, comment => comment.votes, { nullable: true })
-  @JoinColumn({ name: 'uuid_comment' })
+  @JoinColumn({ name: 'id_comment' })
   comment?: Comment;
 }

--- a/src/votes/votes.controller.spec.ts
+++ b/src/votes/votes.controller.spec.ts
@@ -11,18 +11,18 @@ describe('VotesController', () => {
   let service: VotesService;
 
   const mockMember = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+    idMember: '123e4567-e89b-12d3-a456-426614174000',
     guildUsername: 'TestUser',
     communityRole: 'Member',
   };
 
   const mockResource = {
-    uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+    idResource: '123e4567-e89b-12d3-a456-426614174001',
     title: 'Test Resource',
   };
 
   const mockVote: Vote = {
-    uuidVote: '123e4567-e89b-12d3-a456-426614174003',
+    idVote: '123e4567-e89b-12d3-a456-426614174003',
     voteType: VoteType.UPVOTE,
     member: mockMember,
     resource: mockResource,
@@ -31,9 +31,9 @@ describe('VotesController', () => {
   } as Vote;
 
   const mockCreateVoteDto: CreateVoteDto = {
-    uuidMember: mockMember.uuidMember,
+    idMember: mockMember.idMember,
     voteType: VoteType.UPVOTE,
-    uuidResource: mockResource.uuidResource,
+    idResource: mockResource.idResource,
   };
 
   beforeEach(async () => {
@@ -88,9 +88,9 @@ describe('VotesController', () => {
 
   describe('findOne', () => {
     it('devrait retourner un vote spécifique', async () => {
-      const result = await controller.findOne(mockVote.uuidVote);
+      const result = await controller.findOne(mockVote.idVote);
       expect(result).toEqual(mockVote);
-      expect(service.findOne).toHaveBeenCalledWith(mockVote.uuidVote);
+      expect(service.findOne).toHaveBeenCalledWith(mockVote.idVote);
     });
 
     it('devrait gérer les votes non trouvés', async () => {
@@ -102,7 +102,7 @@ describe('VotesController', () => {
 
     it('devrait gérer les erreurs lors de la récupération', async () => {
       vi.spyOn(service, 'findOne').mockRejectedValueOnce(new Error());
-      await expect(controller.findOne(mockVote.uuidVote)).rejects.toThrow(
+      await expect(controller.findOne(mockVote.idVote)).rejects.toThrow(
         new HttpException('Erreur lors de la récupération du vote', HttpStatus.INTERNAL_SERVER_ERROR)
       );
     });
@@ -110,8 +110,8 @@ describe('VotesController', () => {
 
   describe('remove', () => {
     it('devrait supprimer un vote', async () => {
-      await controller.remove(mockVote.uuidVote);
-      expect(service.remove).toHaveBeenCalledWith(mockVote.uuidVote);
+      await controller.remove(mockVote.idVote);
+      expect(service.remove).toHaveBeenCalledWith(mockVote.idVote);
     });
 
     it('devrait gérer les votes non trouvés', async () => {
@@ -123,7 +123,7 @@ describe('VotesController', () => {
 
     it('devrait gérer les erreurs lors de la suppression', async () => {
       vi.spyOn(service, 'remove').mockRejectedValueOnce(new Error());
-      await expect(controller.remove(mockVote.uuidVote)).rejects.toThrow(
+      await expect(controller.remove(mockVote.idVote)).rejects.toThrow(
         new HttpException('Erreur lors de la suppression du vote', HttpStatus.INTERNAL_SERVER_ERROR)
       );
     });

--- a/src/votes/votes.controller.ts
+++ b/src/votes/votes.controller.ts
@@ -28,9 +28,9 @@ export class VotesController {
     content: {
       'application/json': {
         example: {
-          voteUuid: '123e4567-e89b-12d3-a456-426614174000',
-          userId: '123e4567-e89b-12d3-a456-426614174001',
-          itemId: '123e4567-e89b-12d3-a456-426614174002',
+          idVote: '123e4567-e89b-12d3-a456-426614174000',
+          idUser: '123e4567-e89b-12d3-a456-426614174001',
+          idItem: '123e4567-e89b-12d3-a456-426614174002',
           voteType: 'upvote',
           voteCreatedAt: '2024-01-01T00:00:00Z',
           voteUpdatedAt: '2024-01-01T00:00:00Z'
@@ -71,9 +71,9 @@ export class VotesController {
     content: {
       'application/json': {
         example: [{
-          voteUuid: '123e4567-e89b-12d3-a456-426614174000',
-          userId: '123e4567-e89b-12d3-a456-426614174001',
-          itemId: '123e4567-e89b-12d3-a456-426614174002',
+          idVote: '123e4567-e89b-12d3-a456-426614174000',
+          idUser: '123e4567-e89b-12d3-a456-426614174001',
+          idItem: '123e4567-e89b-12d3-a456-426614174002',
           voteType: 'upvote',
           voteCreatedAt: '2024-01-01T00:00:00Z',
           voteUpdatedAt: '2024-01-01T00:00:00Z'
@@ -115,9 +115,9 @@ export class VotesController {
     content: {
       'application/json': {
         example: {
-          voteUuid: '123e4567-e89b-12d3-a456-426614174000',
-          userId: '123e4567-e89b-12d3-a456-426614174001',
-          itemId: '123e4567-e89b-12d3-a456-426614174002',
+          idVote: '123e4567-e89b-12d3-a456-426614174000',
+          idUser: '123e4567-e89b-12d3-a456-426614174001',
+          idItem: '123e4567-e89b-12d3-a456-426614174002',
           voteType: 'upvote',
           voteCreatedAt: '2024-01-01T00:00:00Z',
           voteUpdatedAt: '2024-01-01T00:00:00Z'

--- a/src/votes/votes.service.spec.ts
+++ b/src/votes/votes.service.spec.ts
@@ -18,23 +18,23 @@ describe('VotesService', () => {
   let commentRepository: Repository<Comment>;
 
   const mockMember = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+    idMember: '123e4567-e89b-12d3-a456-426614174000',
     guildUsername: 'TestUser',
     communityRole: 'Member',
   } as Member;
 
   const mockResource = {
-    uuidResource: '123e4567-e89b-12d3-a456-426614174001',
+    idResource: '123e4567-e89b-12d3-a456-426614174001',
     title: 'Test Resource',
   } as Resource;
 
   const mockComment = {
-    uuidComment: '123e4567-e89b-12d3-a456-426614174002',
+    idComment: '123e4567-e89b-12d3-a456-426614174002',
     content: 'Test Comment',
   } as Comment;
 
   const mockVote = {
-    uuidVote: '123e4567-e89b-12d3-a456-426614174003',
+    idVote: '123e4567-e89b-12d3-a456-426614174003',
     voteType: VoteType.UPVOTE,
     member: mockMember,
     resource: mockResource,
@@ -43,15 +43,15 @@ describe('VotesService', () => {
   } as Vote;
 
   const mockCreateResourceVoteDto: CreateVoteDto = {
-    uuidMember: mockMember.uuidMember,
+    idMember: mockMember.idMember,
     voteType: VoteType.UPVOTE,
-    uuidResource: mockResource.uuidResource,
+    idResource: mockResource.idResource,
   };
 
   const mockCreateCommentVoteDto: CreateVoteDto = {
-    uuidMember: mockMember.uuidMember,
+    idMember: mockMember.idMember,
     voteType: VoteType.UPVOTE,
-    uuidComment: mockComment.uuidComment,
+    idComment: mockComment.idComment,
   };
 
   beforeEach(async () => {
@@ -152,10 +152,10 @@ describe('VotesService', () => {
   describe('findOne', () => {
     it('devrait retourner un vote spécifique', async () => {
       vi.spyOn(voteRepository, 'findOne').mockResolvedValueOnce(mockVote);
-      const result = await service.findOne(mockVote.uuidVote);
+      const result = await service.findOne(mockVote.idVote);
       expect(result).toEqual(mockVote);
       expect(voteRepository.findOne).toHaveBeenCalledWith({
-        where: { uuidVote: mockVote.uuidVote },
+        where: { idVote: mockVote.idVote },
         relations: ['member', 'resource', 'comment']
       });
     });
@@ -170,7 +170,7 @@ describe('VotesService', () => {
   describe('remove', () => {
     it('devrait supprimer un vote', async () => {
       vi.spyOn(voteRepository, 'findOne').mockResolvedValueOnce(mockVote);
-      const result = await service.remove(mockVote.uuidVote);
+      const result = await service.remove(mockVote.idVote);
       expect(result).toBe(true);
     });
 

--- a/src/votes/votes.service.ts
+++ b/src/votes/votes.service.ts
@@ -23,56 +23,56 @@ export class VotesService {
   async create(createVoteDto: CreateVoteDto): Promise<Vote> {
     // Vérifier que le membre existe
     const member = await this.memberRepository.findOne({
-      where: { uuidMember: createVoteDto.uuidMember }
+      where: { idMember: createVoteDto.idMember }
     });
     if (!member) {
-      throw new NotFoundException(`Member with UUID ${createVoteDto.uuidMember} not found`);
+      throw new NotFoundException(`Member with id ${createVoteDto.idMember} not found`);
     }
 
     // Vérifier si c'est un vote sur une ressource ou un commentaire
     let resource: Resource | undefined;
     let comment: Comment | undefined;
 
-    if (createVoteDto.uuidResource) {
+    if (createVoteDto.idResource) {
       const foundResource = await this.resourceRepository.findOne({
-        where: { uuidResource: createVoteDto.uuidResource }
+        where: { idResource: createVoteDto.idResource }
       });
       if (!foundResource) {
-        throw new NotFoundException(`Resource with UUID ${createVoteDto.uuidResource} not found`);
+        throw new NotFoundException(`Resource with id ${createVoteDto.idResource} not found`);
       }
       resource = foundResource;
 
       // Vérifier si le membre a déjà voté pour cette ressource
       const existingVote = await this.voteRepository.findOne({
         where: {
-          member: { uuidMember: member.uuidMember },
-          resource: { uuidResource: resource.uuidResource }
+          member: { idMember: member.idMember },
+          resource: { idResource: resource.idResource }
         }
       });
       if (existingVote) {
         throw new ConflictException(`Member has already voted for this resource`);
       }
-    } else if (createVoteDto.uuidComment) {
+    } else if (createVoteDto.idComment) {
       const foundComment = await this.commentRepository.findOne({
-        where: { uuidComment: createVoteDto.uuidComment }
+        where: { idComment: createVoteDto.idComment }
       });
       if (!foundComment) {
-        throw new NotFoundException(`Comment with UUID ${createVoteDto.uuidComment} not found`);
+        throw new NotFoundException(`Comment with id ${createVoteDto.idComment} not found`);
       }
       comment = foundComment;
 
       // Vérifier si le membre a déjà voté pour ce commentaire
       const existingVote = await this.voteRepository.findOne({
         where: {
-          member: { uuidMember: member.uuidMember },
-          comment: { uuidComment: comment.uuidComment }
+          member: { idMember: member.idMember },
+          comment: { idComment: comment.idComment }
         }
       });
       if (existingVote) {
         throw new ConflictException(`Member has already voted for this comment`);
       }
     } else {
-      throw new Error('Either uuidResource or uuidComment must be provided');
+      throw new Error('Either idResource or idComment must be provided');
     }
 
     // Créer le vote
@@ -92,17 +92,17 @@ export class VotesService {
     });
   }
 
-  async findOne(uuid: string): Promise<Vote | null> {
+  async findOne(idVote: string): Promise<Vote | null> {
     return await this.voteRepository.findOne({
-      where: { uuidVote: uuid },
+      where: { idVote: idVote },
       relations: ['member', 'resource', 'comment']
     });
   }
 
-  async remove(uuid: string): Promise<boolean> {
-    const vote = await this.findOne(uuid);
+  async remove(idVote: string): Promise<boolean> {
+    const vote = await this.findOne(idVote);
     if (!vote) {
-      throw new NotFoundException(`Vote with UUID ${uuid} not found`);
+      throw new NotFoundException(`Vote with id ${idVote} not found`);
     }
     
     await this.voteRepository.remove(vote);

--- a/src/xp-transactions/dto/create-xp-transaction.dto.spec.ts
+++ b/src/xp-transactions/dto/create-xp-transaction.dto.spec.ts
@@ -8,7 +8,7 @@ describe('CreateXpTransactionDto', () => {
 
   beforeEach(() => {
     dto = new CreateXpTransactionDto();
-    dto.uuidMember = '123e4567-e89b-12d3-a456-426614174000';
+    dto.idMember = '123e4567-e89b-12d3-a456-426614174000';
     dto.transactionType = XpTransactionType.GAIN;
     dto.source = XpTransactionSource.VOTE;
     dto.transactionValue = '100.00';
@@ -20,19 +20,19 @@ describe('CreateXpTransactionDto', () => {
     expect(errors.length).toBe(0);
   });
 
-  describe('uuidMember', () => {
-    it('devrait échouer si uuidMember n\'est pas une chaîne', async () => {
-      (dto as any).uuidMember = 123;
+  describe('idMember', () => {
+    it('devrait échouer si idMember n\'est pas une chaîne', async () => {
+      (dto as any).idMember = 123;
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].property).toBe('uuidMember');
+      expect(errors[0].property).toBe('idMember');
     });
 
-    it('devrait échouer si uuidMember n\'est pas un UUID valide', async () => {
-      dto.uuidMember = '123';
+    it('devrait échouer si idMember n\'est pas un UUID valide', async () => {
+      dto.idMember = '123';
       const errors = await validate(dto);
       expect(errors.length).toBeGreaterThan(0);
-      expect(errors[0].property).toBe('uuidMember');
+      expect(errors[0].property).toBe('idMember');
     });
   });
 

--- a/src/xp-transactions/dto/create-xp-transaction.dto.ts
+++ b/src/xp-transactions/dto/create-xp-transaction.dto.ts
@@ -1,7 +1,7 @@
 import { IsString, MaxLength, IsEnum, IsOptional, IsDecimal, IsUUID } from 'class-validator';
 import { ApiProperty, PickType } from '@nestjs/swagger';
 import { XpTransactionType, XpTransactionSource, ReferenceType } from '../entities/xp-transaction.entity';
-import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-fields';
+import { PickableInternIdFields } from '../../utils/pickable-intern-id-fields';
 
 /**
  * Data Transfer Object pour la création d'une transaction XP
@@ -14,7 +14,7 @@ import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-field
  * @example
  * ```typescript
  * const transaction = new CreateXpTransactionDto();
- * transaction.uuidMember = "123e4567-e89b-12d3-a456-426614174000";
+ * transaction.idMember = "123e4567-e89b-12d3-a456-426614174000";
  * transaction.amount = 100;
  * transaction.reason = "Participation active";
  * transaction.notes = "Aide exceptionnelle"; // Optionnel
@@ -23,8 +23,8 @@ import { PickableInternUUIDFields } from '../../utils/pickable-intern-uuid-field
  * @see XpTransactionsService
  * @see XpTransactionsController
  */
-export class CreateXpTransactionDto extends PickType(PickableInternUUIDFields, [
-  'uuidMember'
+export class CreateXpTransactionDto extends PickType(PickableInternIdFields, [
+  'idMember'
 ]) {
   @ApiProperty({
     description: 'Type de la transaction',
@@ -86,5 +86,5 @@ export class CreateXpTransactionDto extends PickType(PickableInternUUIDFields, [
   })
   @IsOptional()
   @IsUUID()
-  referenceUuid?: string;
+  idReference?: string;
 }

--- a/src/xp-transactions/dto/responses/xp-transaction.response.dto.ts
+++ b/src/xp-transactions/dto/responses/xp-transaction.response.dto.ts
@@ -8,7 +8,7 @@ export class XpTransactionMemberResponseDto {
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @Expose()
-  uuidMember: string;
+  idMember: string;
 
   @ApiProperty({
     description: 'Nom d\'utilisateur sur le serveur',
@@ -38,10 +38,10 @@ export class XpTransactionMemberResponseDto {
   status: string;
 
   @Exclude()
-  uuidDiscord: string;
+  idDiscord: string;
 
   @Exclude()
-  uuidGuild: string;
+  idGuild: string;
 
   @Exclude()
   xp: string;
@@ -53,7 +53,7 @@ export class XpTransactionResponseDto {
     example: '550e8400-e29b-41d4-a716-446655440000'
   })
   @Expose()
-  uuidXpTransaction: string;
+  idXpTransaction: string;
 
   @ApiProperty({
     description: 'Type de la transaction',
@@ -108,7 +108,7 @@ export class XpTransactionResponseDto {
     required: false
   })
   @Expose()
-  referenceUuid?: string;
+  idReference?: string;
 
   @ApiProperty({
     description: 'Date de création',

--- a/src/xp-transactions/entities/xp-transaction.entity.ts
+++ b/src/xp-transactions/entities/xp-transaction.entity.ts
@@ -30,11 +30,11 @@ export enum ReferenceType {
 @Entity('xp_transactions')
 export class XpTransaction {
   @ApiProperty({
-    description: 'UUID unique de la transaction XP',
+    description: 'id unique de la transaction XP',
     example: '550e8400-e29b-41d4-a716-446655440000'
   })
-  @PrimaryGeneratedColumn('uuid', { name: 'uuid_xp_transaction' })
-  uuidXpTransaction: string;
+  @PrimaryGeneratedColumn('uuid', { name: 'id_xp_transaction' })
+  idXpTransaction: string;
 
   @ApiProperty({
     description: 'Type de la transaction (GAIN ou LOSS)',
@@ -111,16 +111,16 @@ export class XpTransaction {
   referenceType?: ReferenceType;
 
   @ApiProperty({
-    description: 'UUID de l\'objet référencé',
+    description: 'id de l\'objet référencé',
     example: '123e4567-e89b-12d3-a456-426614174000',
     required: false
   })
   @Column({ 
     type: 'uuid', 
     nullable: true,
-    name: 'reference_uuid'
+    name: 'id_reference'
   })
-  referenceUuid?: string;
+  idReference?: string;
 
   @ApiProperty({
     description: 'Date de création',
@@ -134,6 +134,6 @@ export class XpTransaction {
     type: () => Member
   })
   @ManyToOne(() => Member, member => member.xpTransactions)
-  @JoinColumn({ name: 'uuid_member' })
+  @JoinColumn({ name: 'id_member' })
   member: Member;
 }

--- a/src/xp-transactions/xp-transactions.controller.ts
+++ b/src/xp-transactions/xp-transactions.controller.ts
@@ -39,14 +39,14 @@ export class XpTransactionsController {
     return await this.xpTransactionsService.findAll();
   }
 
-  @Get('member/:uuid')
+  @Get('member/:idMember')
   @ApiOperation({ 
     summary: 'Récupérer les transactions XP d\'un membre',
     description: 'Retourne la liste des transactions XP d\'un membre spécifique.'
   })
   @ApiParam({ 
-    name: 'uuid',
-    description: 'UUID du membre dont on veut récupérer les transactions',
+    name: 'idMember',
+    description: 'id du membre dont on veut récupérer les transactions',
     example: '123e4567-e89b-12d3-a456-426614174000'
   })
   @ApiResponse({ 
@@ -55,13 +55,13 @@ export class XpTransactionsController {
     type: [XpTransactionResponseDto] 
   })
   @ApiResponse({ status: 404, description: 'Membre non trouvé' })
-  async findByMember(@Param('uuid') uuid: string): Promise<XpTransactionResponseDto[]> {
-    return await this.xpTransactionsService.findByMember(uuid);
+  async findByMember(@Param('idMember') idMember: string): Promise<XpTransactionResponseDto[]> {
+    return await this.xpTransactionsService.findByMember(idMember);
   }
 
-  @Get(':uuid')
+  @Get(':idXpTransaction')
   @ApiOperation({ 
-    summary: 'Récupérer une transaction XP par son UUID',
+    summary: 'Récupérer une transaction XP par son id',
     description: 'Retourne les détails d\'une transaction XP spécifique.'
   })
   @ApiResponse({ 
@@ -70,11 +70,11 @@ export class XpTransactionsController {
     type: XpTransactionResponseDto 
   })
   @ApiResponse({ status: 404, description: 'Transaction XP non trouvée' })
-  async findOne(@Param('uuid') uuid: string): Promise<XpTransactionResponseDto> {
-    return await this.xpTransactionsService.findOne(uuid);
+  async findOne(@Param('idXpTransaction') idXpTransaction: string): Promise<XpTransactionResponseDto> {
+    return await this.xpTransactionsService.findOne(idXpTransaction);
   }
 
-  @Delete(':uuid')
+  @Delete(':idXpTransaction')
   @ApiOperation({ 
     summary: 'Supprimer une transaction XP',
     description: 'Supprime une transaction XP existante.'
@@ -84,7 +84,7 @@ export class XpTransactionsController {
     description: 'La transaction XP a été supprimée avec succès.' 
   })
   @ApiResponse({ status: 404, description: 'Transaction XP non trouvée' })
-  async remove(@Param('uuid') uuid: string): Promise<void> {
-    return await this.xpTransactionsService.remove(uuid);
+  async remove(@Param('idXpTransaction') idXpTransaction: string): Promise<void> {
+    return await this.xpTransactionsService.remove(idXpTransaction);
   }
 }

--- a/src/xp-transactions/xp-transactions.service.spec.ts
+++ b/src/xp-transactions/xp-transactions.service.spec.ts
@@ -14,13 +14,13 @@ describe('XpTransactionsService', () => {
   let memberRepository: Repository<Member>;
 
   const mockMember = {
-    uuidMember: '123e4567-e89b-12d3-a456-426614174000',
+    idMember: '123e4567-e89b-12d3-a456-426614174000',
     guildUsername: 'TestUser',
     communityRole: 'Member',
   } as Member;
 
   const mockXpTransaction = {
-    uuidXpTransaction: '123e4567-e89b-12d3-a456-426614174001',
+    idXpTransaction: '123e4567-e89b-12d3-a456-426614174001',
     transactionType: XpTransactionType.GAIN,
     source: XpTransactionSource.VOTE,
     transactionValue: '100.00',
@@ -31,7 +31,7 @@ describe('XpTransactionsService', () => {
   } as XpTransaction;
 
   const mockCreateDto: CreateXpTransactionDto = {
-    uuidMember: mockMember.uuidMember,
+    idMember: mockMember.idMember,
     transactionType: XpTransactionType.GAIN,
     source: XpTransactionSource.VOTE,
     transactionValue: '100.00',
@@ -93,15 +93,15 @@ describe('XpTransactionsService', () => {
     it('devrait retourner toutes les transactions XP', async () => {
       const result = await service.findAll();
       expect(result).toHaveLength(1);
-      expect(result[0].uuidXpTransaction).toBe(mockXpTransaction.uuidXpTransaction);
+      expect(result[0].idXpTransaction).toBe(mockXpTransaction.idXpTransaction);
     });
   });
 
   describe('findByMember', () => {
     it('devrait retourner les transactions XP d\'un membre', async () => {
-      const result = await service.findByMember(mockMember.uuidMember);
+      const result = await service.findByMember(mockMember.idMember);
       expect(result).toHaveLength(1);
-      expect(result[0].member.uuidMember).toBe(mockMember.uuidMember);
+      expect(result[0].member.idMember).toBe(mockMember.idMember);
     });
 
     it('devrait lever une exception si le membre n\'existe pas', async () => {
@@ -112,8 +112,8 @@ describe('XpTransactionsService', () => {
 
   describe('findOne', () => {
     it('devrait retourner une transaction XP spécifique', async () => {
-      const result = await service.findOne(mockXpTransaction.uuidXpTransaction);
-      expect(result.uuidXpTransaction).toBe(mockXpTransaction.uuidXpTransaction);
+      const result = await service.findOne(mockXpTransaction.idXpTransaction);
+      expect(result.idXpTransaction).toBe(mockXpTransaction.idXpTransaction);
     });
 
     it('devrait lever une exception si la transaction n\'existe pas', async () => {
@@ -124,7 +124,7 @@ describe('XpTransactionsService', () => {
 
   describe('remove', () => {
     it('devrait lever une exception car la suppression n\'est pas autorisée', async () => {
-      await expect(service.remove(mockXpTransaction.uuidXpTransaction)).rejects.toThrow(BadRequestException);
+      await expect(service.remove(mockXpTransaction.idXpTransaction)).rejects.toThrow(BadRequestException);
     });
   });
 }); 

--- a/src/xp-transactions/xp-transactions.service.ts
+++ b/src/xp-transactions/xp-transactions.service.ts
@@ -18,11 +18,11 @@ export class XpTransactionsService {
 
   async create(createXpTransactionDto: CreateXpTransactionDto): Promise<XpTransactionResponseDto> {
     const member = await this.memberRepository.findOne({
-      where: { uuidMember: createXpTransactionDto.uuidMember }
+      where: { idMember: createXpTransactionDto.idMember }
     });
 
     if (!member) {
-      throw new NotFoundException(`Member with UUID ${createXpTransactionDto.uuidMember} not found`);
+      throw new NotFoundException(`Member with id ${createXpTransactionDto.idMember} not found`);
     }
 
     // Vérifier que la valeur est un nombre valide
@@ -39,7 +39,7 @@ export class XpTransactionsService {
       reason: createXpTransactionDto.reason,
       notes: createXpTransactionDto.notes,
       referenceType: createXpTransactionDto.referenceType,
-      referenceUuid: createXpTransactionDto.referenceUuid,
+      idReference: createXpTransactionDto.idReference,
       member,
     });
 
@@ -47,7 +47,7 @@ export class XpTransactionsService {
     
     // Retourner la transaction avec ses relations
     const transactionWithRelations = await this.xpTransactionRepository.findOne({
-      where: { uuidXpTransaction: savedTransaction.uuidXpTransaction },
+      where: { idXpTransaction: savedTransaction.idXpTransaction },
       relations: ['member'],
     });
 
@@ -69,19 +69,19 @@ export class XpTransactionsService {
     );
   }
 
-  async findByMember(uuidMember: string): Promise<XpTransactionResponseDto[]> {
+  async findByMember(idMember: string): Promise<XpTransactionResponseDto[]> {
     // Vérifier que le membre existe
     const member = await this.memberRepository.findOne({
-      where: { uuidMember }
+      where: { idMember }
     });
 
     if (!member) {
-      throw new NotFoundException(`Member with UUID ${uuidMember} not found`);
+      throw new NotFoundException(`Member with id ${idMember} not found`);
     }
 
     // Récupérer toutes les transactions du membre
     const transactions = await this.xpTransactionRepository.find({
-      where: { member: { uuidMember } },
+      where: { member: { idMember } },
       relations: ['member'],
       order: {
         createdAt: 'DESC'
@@ -93,20 +93,20 @@ export class XpTransactionsService {
     );
   }
 
-  async findOne(uuid: string): Promise<XpTransactionResponseDto> {
+  async findOne(idXpTransaction : string): Promise<XpTransactionResponseDto> {
     const transaction = await this.xpTransactionRepository.findOne({
-      where: { uuidXpTransaction: uuid },
+      where: { idXpTransaction: idXpTransaction },
       relations: ['member']
     });
 
     if (!transaction) {
-      throw new NotFoundException(`Transaction XP avec l'UUID ${uuid} non trouvée`);
+      throw new NotFoundException(`Transaction XP avec l'id ${idXpTransaction} non trouvée`);
     }
 
     return plainToInstance(XpTransactionResponseDto, transaction, { excludeExtraneousValues: true });
   }
 
-  async remove(uuid: string): Promise<void> {
+  async remove(idXpTransaction: string): Promise<void> {
     throw new BadRequestException('Les transactions XP ne peuvent pas être supprimées');
   }
 }

--- a/tests/answers.e2e.spec.ts
+++ b/tests/answers.e2e.spec.ts
@@ -6,7 +6,7 @@ test.describe('Answers API E2E Tests', () => {
   
   const testAnswer: CreateAnswerQuestionDto = {
     content: 'Test answer content',
-    uuidQuestion: '123e4567-e89b-12d3-a456-426614174000'
+    idQuestion: '123e4567-e89b-12d3-a456-426614174000'
   };
 
   let createdAnswerUuid: string;
@@ -66,7 +66,7 @@ test.describe('Answers API E2E Tests', () => {
     createdAnswerUuid = createData.data.uuid;
 
     // 2. Récupération de la réponse créée
-    console.log(`Fetching created answer with UUID: ${createdAnswerUuid}...`);
+    console.log(`Fetching created answer with id: ${createdAnswerUuid}...`);
     const getResponse = await request.get(`${API_URL}/answers/${createdAnswerUuid}`);
     console.log(`Get response status: ${getResponse.status()}`);
     const getResponseText = await getResponse.text();
@@ -141,7 +141,7 @@ test.describe('Answers API E2E Tests', () => {
     // Test avec UUID invalide
     console.log('Testing invalid UUID...');
     const invalidUuidResponse = await request.post(`${API_URL}/answers`, {
-      data: { ...testAnswer, uuidQuestion: 'invalid-uuid' },
+      data: { ...testAnswer, idQuestion: 'invalid-uuid' },
       headers: {
         'Content-Type': 'application/json'
       }
@@ -149,7 +149,7 @@ test.describe('Answers API E2E Tests', () => {
     expect(invalidUuidResponse.status()).toBe(400);
     const invalidUuidData = JSON.parse(await invalidUuidResponse.text());
     expect(invalidUuidData.message).toEqual(
-      expect.arrayContaining(['uuidQuestion must be a UUID'])
+      expect.arrayContaining(['idQuestion must be a UUID'])
     );
 
     // Test avec requête malformée

--- a/tests/signature.e2e-spec.ts
+++ b/tests/signature.e2e-spec.ts
@@ -62,13 +62,13 @@ describe('SignatureController (e2e)', () => {
 
   describe('/signature/promotion/:uuid (GET)', () => {
     it('should return promotion data for valid UUID', () => {
-      const uuid = '123e4567-e89b-12d3-a456-426614174000';
+      const idPromotion = '123e4567-e89b-12d3-a456-426614174000';
       return request(app.getHttpServer())
-        .get(`/signature/promotion/${uuid}`)
+        .get(`/signature/promotion/${idPromotion}`)
         .expect(200)
         .expect((res) => {
           expect(res.body).toHaveProperty('promotion');
-          expect(res.body.promotion.uuid).toBe(uuid);
+          expect(res.body.promotion.idPromotion).toBe(idPromotion);
           expect(res.body.promotion.nom).toBe('Promotion 2023');
           
           // Vérifier la structure du forum


### PR DESCRIPTION
**Overview**
This PR implements a comprehensive standardization of entity naming conventions and relationships across the application. It ensures consistency between database and TypeScript naming patterns while fixing relationship cardinalities.

**Key Changes**
- Standardized ID naming convention:
- Database: id_xxx (snake_case)
- TypeScript: idXxx (camelCase)
- Fixed relationship cardinalities:
- Category-Course: OneToMany
- Category-Campus: OneToMany
- Category-Promotion: OneToOne
- Updated all entity tests to reflect new naming patterns
- Enhanced Swagger documentation

**Breaking Changes** ⚠️
- This update includes breaking changes that will affect API responses and require frontend adjustments:
- Modified relationship structures
- Updated property naming conventions
- Changed response formats for several endpoints

**Testing**
- Unit tests have been updated  ⚠️ some of them will need further fixes

**Migration Notes**
Frontend teams will need to update their integrations to accommodate these changes, particularly for endpoints involving Category, Campus, and Course entities.